### PR TITLE
Add publishers and categories read endpoints

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -2,6 +2,8 @@ import os
 from flask import Flask
 from routes.games import games_bp
 from routes.auth import auth_bp
+from routes.publishers import publishers_bp
+from routes.categories import categories_bp
 from models import db
 from utils.database import get_connection_string
 from utils.seed_database import seed_database
@@ -24,6 +26,8 @@ with app.app_context():
 # Register blueprints
 app.register_blueprint(games_bp)
 app.register_blueprint(auth_bp)
+app.register_blueprint(publishers_bp)
+app.register_blueprint(categories_bp)
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5100) # Port 5100 to avoid macOS conflicts

--- a/server/routes/categories.py
+++ b/server/routes/categories.py
@@ -1,0 +1,34 @@
+from flask import jsonify, Response, Blueprint
+from models import db, Category, Game
+
+categories_bp = Blueprint('categories', __name__)
+
+
+@categories_bp.route('/api/categories', methods=['GET'])
+def get_categories() -> Response:
+    categories = db.session.query(Category).order_by(Category.name.asc()).all()
+    return jsonify({
+        "categories": [category.to_dict() for category in categories],
+    })
+
+
+@categories_bp.route('/api/categories/<int:id>', methods=['GET'])
+def get_category(id: int) -> tuple[Response, int] | Response:
+    category = db.session.query(Category).filter(Category.id == id).first()
+
+    if not category:
+        return jsonify({"error": "Category not found"}), 404
+
+    games = db.session.query(Game).filter(
+        Game.category_id == id
+    ).order_by(Game.title.asc()).all()
+
+    return jsonify({
+        "id": category.id,
+        "name": category.name,
+        "description": category.description,
+        "games": [
+            {"id": game.id, "title": game.title}
+            for game in games
+        ],
+    })

--- a/server/routes/publishers.py
+++ b/server/routes/publishers.py
@@ -1,0 +1,34 @@
+from flask import jsonify, Response, Blueprint
+from models import db, Publisher, Game
+
+publishers_bp = Blueprint('publishers', __name__)
+
+
+@publishers_bp.route('/api/publishers', methods=['GET'])
+def get_publishers() -> Response:
+    publishers = db.session.query(Publisher).order_by(Publisher.name.asc()).all()
+    return jsonify({
+        "publishers": [publisher.to_dict() for publisher in publishers],
+    })
+
+
+@publishers_bp.route('/api/publishers/<int:id>', methods=['GET'])
+def get_publisher(id: int) -> tuple[Response, int] | Response:
+    publisher = db.session.query(Publisher).filter(Publisher.id == id).first()
+
+    if not publisher:
+        return jsonify({"error": "Publisher not found"}), 404
+
+    games = db.session.query(Game).filter(
+        Game.publisher_id == id
+    ).order_by(Game.title.asc()).all()
+
+    return jsonify({
+        "id": publisher.id,
+        "name": publisher.name,
+        "description": publisher.description,
+        "games": [
+            {"id": game.id, "title": game.title}
+            for game in games
+        ],
+    })

--- a/server/tests/test_categories.py
+++ b/server/tests/test_categories.py
@@ -1,0 +1,203 @@
+import unittest
+import json
+from typing import Dict, Any
+from flask import Flask, Response
+from models import Game, Publisher, Category, db
+from routes.categories import categories_bp
+
+
+class TestCategoriesRoutes(unittest.TestCase):
+    TEST_DATA: Dict[str, Any] = {
+        "publishers": [
+            {"name": "DevGames Inc", "description": "A publisher of developer-themed strategy games."},
+            {"name": "Scrum Masters", "description": "Card games for agile teams and other knowledge workers."}
+        ],
+        "categories": [
+            {"name": "Strategy", "description": "Strategy games for thoughtful planners."},
+            {"name": "Card Game", "description": "Card-driven games for groups of any size."}
+        ],
+        "games": [
+            {
+                "title": "Pipeline Panic",
+                "description": "Build your DevOps pipeline before chaos ensues",
+                "publisher_index": 0,
+                "category_index": 0,
+                "star_rating": 4.5
+            },
+            {
+                "title": "Agile Adventures",
+                "description": "Navigate your team through sprints and releases",
+                "publisher_index": 1,
+                "category_index": 1,
+                "star_rating": 4.2
+            },
+            {
+                "title": "Refactor Rampage",
+                "description": "Untangle legacy code before the deadline",
+                "publisher_index": 0,
+                "category_index": 0,
+                "star_rating": 4.0
+            }
+        ]
+    }
+
+    CATEGORIES_API_PATH: str = '/api/categories'
+
+    def setUp(self) -> None:
+        """Set up test database and seed data"""
+        self.app = Flask(__name__)
+        self.app.config['TESTING'] = True
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+        self.app.register_blueprint(categories_bp)
+
+        self.client = self.app.test_client()
+
+        db.init_app(self.app)
+
+        with self.app.app_context():
+            db.create_all()
+            self._seed_test_data()
+
+    def tearDown(self) -> None:
+        """Clean up test database and ensure proper connection closure"""
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+            db.engine.dispose()
+
+    def _seed_test_data(self) -> None:
+        """Helper method to seed test data"""
+        publishers = [
+            Publisher(**publisher_data) for publisher_data in self.TEST_DATA["publishers"]
+        ]
+        db.session.add_all(publishers)
+
+        categories = [
+            Category(**category_data) for category_data in self.TEST_DATA["categories"]
+        ]
+        db.session.add_all(categories)
+
+        db.session.commit()
+
+        games = []
+        for game_data in self.TEST_DATA["games"]:
+            game_dict = game_data.copy()
+            publisher_index = game_dict.pop("publisher_index")
+            category_index = game_dict.pop("category_index")
+
+            games.append(Game(
+                **game_dict,
+                publisher=publishers[publisher_index],
+                category=categories[category_index]
+            ))
+
+        db.session.add_all(games)
+        db.session.commit()
+
+    def _get_response_data(self, response: Response) -> Any:
+        """Helper method to parse response data"""
+        return json.loads(response.data)
+
+    def _get_category_id_by_name(self, name: str) -> int:
+        with self.app.app_context():
+            category = db.session.query(Category).filter_by(name=name).first()
+            return category.id
+
+    def test_get_categories_success(self) -> None:
+        """Test successful retrieval of all categories"""
+        response = self.client.get(self.CATEGORIES_API_PATH)
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('categories', data)
+        self.assertIsInstance(data['categories'], list)
+        self.assertEqual(len(data['categories']), len(self.TEST_DATA["categories"]))
+
+    def test_get_categories_alphabetical_order(self) -> None:
+        """Test that categories are returned in alphabetical order by name"""
+        response = self.client.get(self.CATEGORIES_API_PATH)
+        data = self._get_response_data(response)
+
+        names = [c['name'] for c in data['categories']]
+        self.assertEqual(names, sorted(names))
+
+    def test_get_categories_structure(self) -> None:
+        """Test the structure of each category in the list response"""
+        response = self.client.get(self.CATEGORIES_API_PATH)
+        data = self._get_response_data(response)
+
+        required_fields = ['id', 'name', 'description', 'game_count']
+        for category in data['categories']:
+            for field in required_fields:
+                self.assertIn(field, category)
+
+    def test_get_categories_includes_game_count(self) -> None:
+        """Test that the list response includes an accurate game_count per category"""
+        response = self.client.get(self.CATEGORIES_API_PATH)
+        data = self._get_response_data(response)
+
+        counts_by_name = {c['name']: c['game_count'] for c in data['categories']}
+        self.assertEqual(counts_by_name["Strategy"], 2)
+        self.assertEqual(counts_by_name["Card Game"], 1)
+
+    def test_get_category_by_id_success(self) -> None:
+        """Test retrieving a single category by id with nested games"""
+        category_id = self._get_category_id_by_name("Strategy")
+
+        response = self.client.get(f'{self.CATEGORIES_API_PATH}/{category_id}')
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['id'], category_id)
+        self.assertEqual(data['name'], "Strategy")
+        self.assertIn('description', data)
+        self.assertIn('games', data)
+
+    def test_get_category_by_id_nested_games(self) -> None:
+        """Test that the detail response includes the category's games"""
+        category_id = self._get_category_id_by_name("Strategy")
+
+        response = self.client.get(f'{self.CATEGORIES_API_PATH}/{category_id}')
+        data = self._get_response_data(response)
+
+        titles = sorted(game['title'] for game in data['games'])
+        self.assertEqual(titles, ['Pipeline Panic', 'Refactor Rampage'])
+        for game in data['games']:
+            self.assertIn('id', game)
+            self.assertIn('title', game)
+
+    def test_get_category_by_id_no_games(self) -> None:
+        """Test that a category with no games returns an empty games list"""
+        with self.app.app_context():
+            empty_category = Category(
+                name="Word Game",
+                description="Category for word-based puzzle games.",
+            )
+            db.session.add(empty_category)
+            db.session.commit()
+            empty_id = empty_category.id
+
+        response = self.client.get(f'{self.CATEGORIES_API_PATH}/{empty_id}')
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['games'], [])
+
+    def test_get_category_by_id_not_found(self) -> None:
+        """Test that an unknown category id returns 404"""
+        response = self.client.get(f'{self.CATEGORIES_API_PATH}/99999')
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('error', data)
+
+    def test_get_category_by_invalid_id(self) -> None:
+        """Test that a non-integer id returns 404"""
+        response = self.client.get(f'{self.CATEGORIES_API_PATH}/invalid-id')
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/tests/test_publishers.py
+++ b/server/tests/test_publishers.py
@@ -1,0 +1,203 @@
+import unittest
+import json
+from typing import Dict, Any
+from flask import Flask, Response
+from models import Game, Publisher, Category, db
+from routes.publishers import publishers_bp
+
+
+class TestPublishersRoutes(unittest.TestCase):
+    TEST_DATA: Dict[str, Any] = {
+        "publishers": [
+            {"name": "DevGames Inc", "description": "A publisher of developer-themed strategy games."},
+            {"name": "Scrum Masters", "description": "Card games for agile teams and other knowledge workers."}
+        ],
+        "categories": [
+            {"name": "Strategy", "description": "Strategy games for thoughtful planners."},
+            {"name": "Card Game", "description": "Card-driven games for groups of any size."}
+        ],
+        "games": [
+            {
+                "title": "Pipeline Panic",
+                "description": "Build your DevOps pipeline before chaos ensues",
+                "publisher_index": 0,
+                "category_index": 0,
+                "star_rating": 4.5
+            },
+            {
+                "title": "Agile Adventures",
+                "description": "Navigate your team through sprints and releases",
+                "publisher_index": 1,
+                "category_index": 1,
+                "star_rating": 4.2
+            },
+            {
+                "title": "Refactor Rampage",
+                "description": "Untangle legacy code before the deadline",
+                "publisher_index": 0,
+                "category_index": 0,
+                "star_rating": 4.0
+            }
+        ]
+    }
+
+    PUBLISHERS_API_PATH: str = '/api/publishers'
+
+    def setUp(self) -> None:
+        """Set up test database and seed data"""
+        self.app = Flask(__name__)
+        self.app.config['TESTING'] = True
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+        self.app.register_blueprint(publishers_bp)
+
+        self.client = self.app.test_client()
+
+        db.init_app(self.app)
+
+        with self.app.app_context():
+            db.create_all()
+            self._seed_test_data()
+
+    def tearDown(self) -> None:
+        """Clean up test database and ensure proper connection closure"""
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+            db.engine.dispose()
+
+    def _seed_test_data(self) -> None:
+        """Helper method to seed test data"""
+        publishers = [
+            Publisher(**publisher_data) for publisher_data in self.TEST_DATA["publishers"]
+        ]
+        db.session.add_all(publishers)
+
+        categories = [
+            Category(**category_data) for category_data in self.TEST_DATA["categories"]
+        ]
+        db.session.add_all(categories)
+
+        db.session.commit()
+
+        games = []
+        for game_data in self.TEST_DATA["games"]:
+            game_dict = game_data.copy()
+            publisher_index = game_dict.pop("publisher_index")
+            category_index = game_dict.pop("category_index")
+
+            games.append(Game(
+                **game_dict,
+                publisher=publishers[publisher_index],
+                category=categories[category_index]
+            ))
+
+        db.session.add_all(games)
+        db.session.commit()
+
+    def _get_response_data(self, response: Response) -> Any:
+        """Helper method to parse response data"""
+        return json.loads(response.data)
+
+    def _get_publisher_id_by_name(self, name: str) -> int:
+        with self.app.app_context():
+            publisher = db.session.query(Publisher).filter_by(name=name).first()
+            return publisher.id
+
+    def test_get_publishers_success(self) -> None:
+        """Test successful retrieval of all publishers"""
+        response = self.client.get(self.PUBLISHERS_API_PATH)
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('publishers', data)
+        self.assertIsInstance(data['publishers'], list)
+        self.assertEqual(len(data['publishers']), len(self.TEST_DATA["publishers"]))
+
+    def test_get_publishers_alphabetical_order(self) -> None:
+        """Test that publishers are returned in alphabetical order by name"""
+        response = self.client.get(self.PUBLISHERS_API_PATH)
+        data = self._get_response_data(response)
+
+        names = [p['name'] for p in data['publishers']]
+        self.assertEqual(names, sorted(names))
+
+    def test_get_publishers_structure(self) -> None:
+        """Test the structure of each publisher in the list response"""
+        response = self.client.get(self.PUBLISHERS_API_PATH)
+        data = self._get_response_data(response)
+
+        required_fields = ['id', 'name', 'description', 'game_count']
+        for publisher in data['publishers']:
+            for field in required_fields:
+                self.assertIn(field, publisher)
+
+    def test_get_publishers_includes_game_count(self) -> None:
+        """Test that the list response includes an accurate game_count per publisher"""
+        response = self.client.get(self.PUBLISHERS_API_PATH)
+        data = self._get_response_data(response)
+
+        counts_by_name = {p['name']: p['game_count'] for p in data['publishers']}
+        self.assertEqual(counts_by_name["DevGames Inc"], 2)
+        self.assertEqual(counts_by_name["Scrum Masters"], 1)
+
+    def test_get_publisher_by_id_success(self) -> None:
+        """Test retrieving a single publisher by id with nested games"""
+        publisher_id = self._get_publisher_id_by_name("DevGames Inc")
+
+        response = self.client.get(f'{self.PUBLISHERS_API_PATH}/{publisher_id}')
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['id'], publisher_id)
+        self.assertEqual(data['name'], "DevGames Inc")
+        self.assertIn('description', data)
+        self.assertIn('games', data)
+
+    def test_get_publisher_by_id_nested_games(self) -> None:
+        """Test that the detail response includes the publisher's games"""
+        publisher_id = self._get_publisher_id_by_name("DevGames Inc")
+
+        response = self.client.get(f'{self.PUBLISHERS_API_PATH}/{publisher_id}')
+        data = self._get_response_data(response)
+
+        titles = sorted(game['title'] for game in data['games'])
+        self.assertEqual(titles, ['Pipeline Panic', 'Refactor Rampage'])
+        for game in data['games']:
+            self.assertIn('id', game)
+            self.assertIn('title', game)
+
+    def test_get_publisher_by_id_no_games(self) -> None:
+        """Test that a publisher with no games returns an empty games list"""
+        with self.app.app_context():
+            empty_publisher = Publisher(
+                name="Empty Press",
+                description="A publisher with no games yet.",
+            )
+            db.session.add(empty_publisher)
+            db.session.commit()
+            empty_id = empty_publisher.id
+
+        response = self.client.get(f'{self.PUBLISHERS_API_PATH}/{empty_id}')
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['games'], [])
+
+    def test_get_publisher_by_id_not_found(self) -> None:
+        """Test that an unknown publisher id returns 404"""
+        response = self.client.get(f'{self.PUBLISHERS_API_PATH}/99999')
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('error', data)
+
+    def test_get_publisher_by_invalid_id(self) -> None:
+        """Test that a non-integer id returns 404"""
+        response = self.client.get(f'{self.PUBLISHERS_API_PATH}/invalid-id')
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Adds read endpoints for publishers and categories. Returns the full list of each resource on the index endpoints and a single resource with its nested games on the detail endpoints. This unblocks the API portion of the publisher and category filter work tracked in #51 and #52.

## Related Issue

Partially addresses #51, #52 (API portion only; the frontend filter UI is still pending).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `GET /api/publishers` returns all publishers ordered by name, using `Publisher.to_dict()`.
- `GET /api/publishers/<id>` returns a single publisher with a nested `games` array of `{id, title}`, or 404 if not found.
- `GET /api/categories` and `GET /api/categories/<id>` mirror the publisher endpoints.
- Registers both blueprints in `server/app.py`.
- Adds `server/tests/test_publishers.py` and `server/tests/test_categories.py` covering success, ordering, structure, nested games, empty children, and 404 cases.

## Testing

### Backend Changes

- [x] Ran `./scripts/run-server-tests.sh` — all tests pass (40 tests)
- [x] Added tests in `server/tests/` for the new endpoints

### Frontend Changes

- [ ] N/A — no frontend changes in this PR

## Checklist

- [x] My code follows the project's coding standards
- [x] I have used type hints for Python functions (parameters and return values)
- [ ] N/A — no Svelte components in this PR
- [ ] N/A — no styling in this PR
- [ ] N/A — no documentation changes needed for this PR
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

The detail endpoints return a minimal `{id, title}` per nested game to keep the response small. If a future detail page needs richer game data, that field can be expanded without changing the rest of the shape.
