### PR TITLE
Migrate backend to SQLAlchemy 2.0 style

### DIFF
--- a/.github/instructions/flask-endpoint.instructions.md
+++ b/.github/instructions/flask-endpoint.instructions.md
@@ -9,16 +9,18 @@ applyTo: 'server/routes/*.py'
 
 - Create Blueprint: `bp_name = Blueprint('name', __name__)`
 - Use descriptive names matching resource (e.g., `games_bp`)
-- Include type hints: `Response`, `tuple[Response, int]`, `Query`
+- Include type hints: `Response`, `tuple[Response, int]`, `Select`
 - Import: `from flask import jsonify, Response, Blueprint`
 
 ## Data Access Patterns
 
-- Create base query functions: `get_<resource>_base_query() -> Query`
-- Use SQLAlchemy with outer joins: `isouter=True` for optional relations
+- Create base statement functions: `get_<resource>_base_stmt() -> Select`
+- Use SQLAlchemy 2.0 `select()` (not legacy `Query` / `Model.query`)
+- Use outer joins: `isouter=True` for optional relations
 - Use `contains_eager` for optimized eager loading to avoid N+1 queries
-- Return queries from helpers for reusability across endpoints
-- Use `.all()` for multiple results, `.first()` for single result
+- Return `Select` statements from helpers for reusability across endpoints
+- Execute via `db.session.scalars(stmt).all()` for collections and `db.session.scalars(stmt).one_or_none()` for single rows
+- Use `.unique()` on the scalar result when joining collection relationships to deduplicate parent rows
 
 ## Route Definitions
 
@@ -36,9 +38,9 @@ applyTo: 'server/routes/*.py'
 
 ## Query and Validation
 
-- Filter conditions: `.filter(Model.id == id)`
+- Filter conditions: `stmt.where(Model.id == id)`
 - Check None: `if not result: return jsonify({"error": "..."}), 404`
-- Apply ordering when needed
+- Apply ordering when needed: `stmt.order_by(Model.field.asc())`
 
 ## Required Testing
 

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -1,6 +1,11 @@
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import DeclarativeBase
 
-db = SQLAlchemy()
+class Base(DeclarativeBase):
+    """SQLAlchemy 2.0 declarative base for all models."""
+    pass
+
+db = SQLAlchemy(model_class=Base)
 
 # Import models after db is defined to avoid circular imports
 from .category import Category

--- a/server/models/category.py
+++ b/server/models/category.py
@@ -1,18 +1,21 @@
-from typing import Any
-from sqlalchemy import func
+from typing import Any, List, Optional, TYPE_CHECKING
+from sqlalchemy import String, Text, func, select
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 from . import db
 from .base import BaseModel
-from sqlalchemy.orm import validates, relationship
+
+if TYPE_CHECKING:
+    from .game import Game
 
 class Category(BaseModel):
     __tablename__ = 'categories'
-    
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False, unique=True)
-    description = db.Column(db.Text)
-    
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    description: Mapped[Optional[str]] = mapped_column(Text)
+
     # One-to-many relationship: one category has many games
-    games = relationship("Game", back_populates="category")
+    games: Mapped[List["Game"]] = relationship(back_populates="category")
     
     @validates('name')
     def validate_name(self, key, name):
@@ -27,9 +30,10 @@ class Category(BaseModel):
         
     def to_dict(self) -> dict[str, Any]:
         from .game import Game
+        count_stmt = select(func.count(Game.id)).where(Game.category_id == self.id)
         return {
             'id': self.id,
             'name': self.name,
             'description': self.description,
-            'game_count': db.session.query(func.count(Game.id)).filter(Game.category_id == self.id).scalar() or 0
+            'game_count': db.session.scalar(count_stmt) or 0
         }

--- a/server/models/game.py
+++ b/server/models/game.py
@@ -1,23 +1,27 @@
-from typing import Any
-from . import db
+from typing import Any, Optional, TYPE_CHECKING
+from sqlalchemy import ForeignKey, String, Text, Float
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 from .base import BaseModel
-from sqlalchemy.orm import validates, relationship
+
+if TYPE_CHECKING:
+    from .category import Category
+    from .publisher import Publisher
 
 class Game(BaseModel):
     __tablename__ = 'games'
-    
-    id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.String(100), nullable=False)
-    description = db.Column(db.Text, nullable=False)
-    star_rating = db.Column(db.Float, nullable=True)
-    
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    star_rating: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
     # Foreign keys for one-to-many relationships
-    category_id = db.Column(db.Integer, db.ForeignKey('categories.id'), nullable=False)
-    publisher_id = db.Column(db.Integer, db.ForeignKey('publishers.id'), nullable=False)
-    
+    category_id: Mapped[int] = mapped_column(ForeignKey('categories.id'), nullable=False)
+    publisher_id: Mapped[int] = mapped_column(ForeignKey('publishers.id'), nullable=False)
+
     # One-to-many relationships (many games belong to one category/publisher)
-    category = relationship("Category", back_populates="games")
-    publisher = relationship("Publisher", back_populates="games")
+    category: Mapped["Category"] = relationship(back_populates="games")
+    publisher: Mapped["Publisher"] = relationship(back_populates="games")
     
     @validates('title')
     def validate_name(self, key, name):

--- a/server/models/publisher.py
+++ b/server/models/publisher.py
@@ -1,18 +1,21 @@
-from typing import Any
-from sqlalchemy import func
+from typing import Any, List, Optional, TYPE_CHECKING
+from sqlalchemy import String, Text, func, select
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 from . import db
 from .base import BaseModel
-from sqlalchemy.orm import validates, relationship
+
+if TYPE_CHECKING:
+    from .game import Game
 
 class Publisher(BaseModel):
     __tablename__ = 'publishers'
 
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False, unique=True)
-    description = db.Column(db.Text)
-    
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    description: Mapped[Optional[str]] = mapped_column(Text)
+
     # One-to-many relationship: one publisher has many games
-    games = relationship("Game", back_populates="publisher")
+    games: Mapped[List["Game"]] = relationship(back_populates="publisher")
 
     @validates('name')
     def validate_name(self, key, name):
@@ -27,9 +30,10 @@ class Publisher(BaseModel):
 
     def to_dict(self) -> dict[str, Any]:
         from .game import Game
+        count_stmt = select(func.count(Game.id)).where(Game.publisher_id == self.id)
         return {
             'id': self.id,
             'name': self.name,
             'description': self.description,
-            'game_count': db.session.query(func.count(Game.id)).filter(Game.publisher_id == self.id).scalar() or 0
+            'game_count': db.session.scalar(count_stmt) or 0
         }

--- a/server/routes/games.py
+++ b/server/routes/games.py
@@ -1,6 +1,7 @@
 from flask import jsonify, Response, Blueprint, request
+from sqlalchemy import Select, func, select
+from sqlalchemy.orm import contains_eager
 from models import db, Game, Publisher, Category
-from sqlalchemy.orm import Query, contains_eager
 
 # Create a Blueprint for games routes
 games_bp = Blueprint('games', __name__)
@@ -12,18 +13,15 @@ games_bp = Blueprint('games', __name__)
 
 DEFAULT_PAGE_SIZE = 9
 
-def get_games_base_query() -> Query:
-    return db.session.query(Game).join(
-        Publisher, 
-        Game.publisher_id == Publisher.id, 
-        isouter=True
-    ).join(
-        Category, 
-        Game.category_id == Category.id, 
-        isouter=True
-    ).options(
-        contains_eager(Game.publisher),
-        contains_eager(Game.category)
+def get_games_base_stmt() -> Select:
+    return (
+        select(Game)
+        .join(Publisher, Game.publisher_id == Publisher.id, isouter=True)
+        .join(Category, Game.category_id == Category.id, isouter=True)
+        .options(
+            contains_eager(Game.publisher),
+            contains_eager(Game.category),
+        )
     )
 
 @games_bp.route('/api/games', methods=['GET'])
@@ -35,16 +33,18 @@ def get_games() -> Response:
     page = max(1, page)
     page_size = max(1, min(page_size, 100))
 
-    games_query = get_games_base_query().order_by(Game.title.asc())
+    base_stmt = get_games_base_stmt().order_by(Game.title.asc())
 
     # Get total count before pagination (clear ordering for performance)
-    total = games_query.order_by(None).count()
+    count_stmt = select(func.count()).select_from(base_stmt.order_by(None).subquery())
+    total = db.session.scalar(count_stmt) or 0
     total_pages = max(1, (total + page_size - 1) // page_size)
 
     # Apply pagination
     offset = (page - 1) * page_size
-    games_list = [game.to_dict() for game in games_query.offset(offset).limit(page_size).all()]
-    
+    paginated_stmt = base_stmt.offset(offset).limit(page_size)
+    games_list = [game.to_dict() for game in db.session.scalars(paginated_stmt).unique().all()]
+
     return jsonify({
         "games": games_list,
         "pagination": {
@@ -57,14 +57,13 @@ def get_games() -> Response:
 
 @games_bp.route('/api/games/<int:id>', methods=['GET'])
 def get_game(id: int) -> tuple[Response, int] | Response:
-    # Use the base query and add filter for specific game
-    game_query = get_games_base_query().filter(Game.id == id).first()
-    
+    # Use the base statement and add filter for specific game
+    stmt = get_games_base_stmt().where(Game.id == id)
+    game = db.session.scalars(stmt).unique().one_or_none()
+
     # Return 404 if game not found
-    if not game_query: 
+    if not game:
         return jsonify({"error": "Game not found"}), 404
-    
+
     # Convert the result using the model's to_dict method
-    game = game_query.to_dict()
-    
-    return jsonify(game)
+    return jsonify(game.to_dict())

--- a/server/tests/test_games.py
+++ b/server/tests/test_games.py
@@ -222,8 +222,9 @@ class TestGamesRoutes(unittest.TestCase):
 
     def test_get_games_empty_database(self) -> None:
         """Test retrieval of games when database is empty"""
+        from sqlalchemy import delete
         with self.app.app_context():
-            db.session.query(Game).delete()
+            db.session.execute(delete(Game))
             db.session.commit()
         
         response = self.client.get(self.GAMES_API_PATH)

--- a/server/utils/seed_database.py
+++ b/server/utils/seed_database.py
@@ -2,6 +2,7 @@ import csv
 import os
 import random
 from flask import Flask
+from sqlalchemy import select
 from models import db, Category, Game, Publisher
 from utils.database import get_connection_string
 
@@ -44,7 +45,9 @@ def create_games():
                 # Process category — query DB first for idempotency
                 category_name = row['Category']
                 if category_name not in categories:
-                    category = Category.query.filter_by(name=category_name).first()
+                    category = db.session.scalars(
+                        select(Category).filter_by(name=category_name)
+                    ).first()
                     if not category:
                         category_description = f"Collection of {category_name} games available for crowdfunding"
                         category = Category(
@@ -59,7 +62,9 @@ def create_games():
                 # Process publisher — query DB first for idempotency
                 publisher_name = row['Publisher']
                 if publisher_name not in publishers:
-                    publisher = Publisher.query.filter_by(name=publisher_name).first()
+                    publisher = db.session.scalars(
+                        select(Publisher).filter_by(name=publisher_name)
+                    ).first()
                     if not publisher:
                         publisher_description = f"{publisher_name} is a game publisher seeking funding for exciting new titles"
                         publisher = Publisher(
@@ -72,7 +77,9 @@ def create_games():
                     publishers[publisher_name] = publisher
                 
                 # Check if game already exists by title before creating
-                existing_game = Game.query.filter_by(title=row['Title']).first()
+                existing_game = db.session.scalars(
+                    select(Game).filter_by(title=row['Title'])
+                ).first()
                 if existing_game:
                     games_skipped += 1
                     continue


### PR DESCRIPTION
## Description

Migrates the Flask backend from legacy SQLAlchemy 1.x patterns to the modern 2.0 API. SQLAlchemy 2.0 was already installed; this PR updates the code to actually use it.

## Related Issue

Closes #63

## Type of Change

- [x] 🔧 Refactor (no functional changes)

## Changes Made

- `models/__init__.py`: `db = SQLAlchemy(model_class=Base)` where `Base(DeclarativeBase)`
- Models (`game.py`, `category.py`, `publisher.py`): `db.Column(...)` → `Mapped[]` + `mapped_column(...)`; typed relationships with `Mapped["Foo"]` / `Mapped[List["Foo"]]`
- `routes/games.py`: replaced `db.session.query(...)` with `select()`; helper renamed to `get_games_base_stmt() -> Select`; execute via `db.session.scalars(stmt).unique().all()` / `.one_or_none()`
- `utils/seed_database.py`: `Model.query.filter_by(...)` → `db.session.scalars(select(Model).filter_by(...)).first()`
- `tests/test_games.py`: `db.session.query(Game).delete()` → `db.session.execute(delete(Game))`
- `.github/instructions/flask-endpoint.instructions.md`: documented `Select` patterns

## Testing

### Backend Changes

- [x] Ran `./scripts/run-server-tests.sh` — all 22 tests pass
- [x] Updated `tests/test_games.py` for the new `delete()` pattern

### Frontend Changes

- [ ] N/A — backend-only refactor; API contract unchanged

## Checklist

- [x] My code follows the project's coding standards
- [x] I have used type hints for Python functions (parameters and return values)
- [x] I have updated documentation (instruction files) where needed
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

API responses are unchanged, so the frontend and E2E tests are unaffected.
