### PR TITLE
Cover auth redirects and to_dict serialization in backend tests

### DIFF
--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -1,0 +1,60 @@
+import unittest
+from flask import Flask
+from routes.auth import auth_bp
+
+
+class TestAuthRoutes(unittest.TestCase):
+    """Tests for the /api/login endpoint and its open-redirect protections."""
+
+    LOGIN_API_PATH: str = '/api/login'
+
+    def setUp(self) -> None:
+        self.app = Flask(__name__)
+        self.app.config['TESTING'] = True
+        self.app.register_blueprint(auth_bp)
+        self.client = self.app.test_client()
+
+    def test_login_relative_path_redirects_to_next(self) -> None:
+        """A relative `next` path should be honored as the redirect target."""
+        response = self.client.get(f'{self.LOGIN_API_PATH}?next=/games')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.headers['Location'].endswith('/games'))
+
+    def test_login_no_next_falls_back_to_home(self) -> None:
+        """With no `next` query param, login should redirect to /."""
+        response = self.client.get(self.LOGIN_API_PATH)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.headers['Location'].endswith('/'))
+
+    def test_login_absolute_url_rejected(self) -> None:
+        """An absolute URL with a scheme should be rejected (open-redirect guard)."""
+        response = self.client.get(f'{self.LOGIN_API_PATH}?next=http://evil.com/path')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn('evil.com', response.headers['Location'])
+        self.assertTrue(response.headers['Location'].endswith('/'))
+
+    def test_login_protocol_relative_url_rejected(self) -> None:
+        """A protocol-relative URL (//host/path) should be rejected."""
+        response = self.client.get(f'{self.LOGIN_API_PATH}?next=//evil.com/path')
+
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn('evil.com', response.headers['Location'])
+        self.assertTrue(response.headers['Location'].endswith('/'))
+
+    def test_login_backslash_normalized_before_validation(self) -> None:
+        """Backslashes (which some browsers treat as path separators) should be
+        stripped so they cannot smuggle in a protocol-relative redirect."""
+        response = self.client.get(f'{self.LOGIN_API_PATH}?next=/\\\\evil.com/path')
+
+        self.assertEqual(response.status_code, 302)
+        # After backslash normalization the value becomes "/evil.com/path",
+        # which is a relative path on our own host — the netloc check is not
+        # bypassed.
+        self.assertNotIn('\\', response.headers['Location'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/tests/test_games.py
+++ b/server/tests/test_games.py
@@ -235,6 +235,27 @@ class TestGamesRoutes(unittest.TestCase):
         self.assertEqual(data['pagination']['total'], 0)
         self.assertEqual(data['pagination']['totalPages'], 1)
 
+    def test_get_game_by_id_serialization_contract(self) -> None:
+        """The game JSON contract should expose camelCase `starRating` and
+        nested `{id, name}` objects for publisher and category."""
+        list_response = self.client.get(self.GAMES_API_PATH)
+        game_id = self._get_games_list(list_response)[0]['id']
+
+        response = self.client.get(f'{self.GAMES_API_PATH}/{game_id}')
+        data = self._get_response_data(response)
+
+        self.assertEqual(response.status_code, 200)
+
+        # camelCase, not snake_case
+        self.assertIn('starRating', data)
+        self.assertNotIn('star_rating', data)
+
+        # Nested relations are {id, name} objects, not bare ids
+        self.assertIsInstance(data['publisher'], dict)
+        self.assertEqual(set(data['publisher'].keys()), {'id', 'name'})
+        self.assertIsInstance(data['category'], dict)
+        self.assertEqual(set(data['category'].keys()), {'id', 'name'})
+
     def test_get_game_by_invalid_id_type(self) -> None:
         """Test retrieval of a game with invalid ID type"""
         response = self.client.get(f'{self.GAMES_API_PATH}/invalid-id')

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -196,5 +196,50 @@ class TestModels(unittest.TestCase):
             
             self.assertIn("Description cannot be empty", str(context.exception))
 
+    def test_publisher_to_dict_includes_game_count(self) -> None:
+        """Publisher.to_dict() should report the count of related games."""
+        with self.app.app_context():
+            publisher = Publisher(**self.TEST_DATA["valid_publisher"])
+            category = Category(**self.TEST_DATA["valid_category"])
+            db.session.add_all([publisher, category])
+            db.session.commit()
+
+            # No games yet — count should be 0
+            self.assertEqual(publisher.to_dict()["game_count"], 0)
+
+            # Add two games to this publisher
+            for i in range(2):
+                db.session.add(Game(
+                    title=f"Game {i}",
+                    description="A long enough description for tests",
+                    publisher=publisher,
+                    category=category,
+                    star_rating=4.0,
+                ))
+            db.session.commit()
+
+            self.assertEqual(publisher.to_dict()["game_count"], 2)
+
+    def test_category_to_dict_includes_game_count(self) -> None:
+        """Category.to_dict() should report the count of related games."""
+        with self.app.app_context():
+            publisher = Publisher(**self.TEST_DATA["valid_publisher"])
+            category = Category(**self.TEST_DATA["valid_category"])
+            db.session.add_all([publisher, category])
+            db.session.commit()
+
+            self.assertEqual(category.to_dict()["game_count"], 0)
+
+            db.session.add(Game(
+                title="Lone Game",
+                description="A long enough description for tests",
+                publisher=publisher,
+                category=category,
+                star_rating=4.0,
+            ))
+            db.session.commit()
+
+            self.assertEqual(category.to_dict()["game_count"], 1)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

Adds focused backend tests for three gaps in custom logic, without over-testing the framework or schema.

## Related Issue

Closes #67

## Type of Change

- [x] 🧪 Test update

## Changes Made

- New `server/tests/test_auth.py` covering `/api/login`:
  - relative path is honored as the redirect target
  - missing `next` falls back to `/`
  - absolute URL with scheme is rejected (open-redirect guard)
  - protocol-relative URL (`//host/path`) is rejected
  - backslashes in `next` are normalized so they cannot smuggle in a protocol-relative redirect
- Extended `server/tests/test_models.py` to cover the `game_count` subquery on `Publisher.to_dict()` and `Category.to_dict()` (zero, then non-zero).
- Extended `server/tests/test_games.py` with an explicit camelCase/nested-object contract assertion (`starRating`, `{id, name}`) for the `/api/games/<id>` response.

Backend test count: 22 → 30.

## Testing

### Backend Changes

- [x] Ran `./scripts/run-server-tests.sh` — 30/30 tests pass

### Frontend Changes

- [ ] N/A — backend tests only

## Checklist

- [x] My code follows the project's coding standards
- [x] I have used type hints for Python functions (parameters and return values)
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

Deliberately not added (would test the framework or duplicate existing coverage):

- FK / unique / nullable enforcement (SQLAlchemy)
- Existence of every individual model field (schema)
- More pagination edge cases (already 7 tests)
- E2E-style flows (covered by Playwright)
