### PR TITLE
fix(ci): wire setup-env.sh into frontend-tests job

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,6 +65,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -72,13 +78,8 @@ jobs:
           cache: "npm"
           cache-dependency-path: "./client/package.json"
 
-      - name: Install JavaScript dependencies
-        working-directory: ./client
-        run: npm ci
-
-      - name: Install Playwright browsers
-        working-directory: ./client
-        run: npx playwright install --with-deps
+      - name: Install all dependencies (Python venv, Node modules, Playwright browsers)
+        run: bash ./scripts/setup-env.sh --with-system-deps
 
       - name: Run Playwright e2e tests
         run: bash ./scripts/run-e2e-tests.sh


### PR DESCRIPTION
## Description

The `frontend-tests` CI job was setting up Node.js and installing dependencies manually (`npm ci` + `playwright install --with-deps`) but never calling `setup-env.sh`. This caused the job to always fail because `run-e2e-tests.sh` calls `setup-env.sh --check e2e` before running Playwright, and that check requires:

1. A Python venv to be present (Flask must start for E2E tests)
2. The `client/node_modules/.package-lock.sha256` marker file -- which is only written by `setup-env.sh`, not by a raw `npm ci`

## Related Issue

Closes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `actions/setup-python@v4` (Python 3.13) to `frontend-tests` -- required to create the venv that Flask needs
- Replaced manual `npm ci` + `npx playwright install --with-deps` steps with a single `setup-env.sh --with-system-deps` call, which handles Python venv, Node modules, Playwright browsers, and all marker files in one shot
- This mirrors the pattern already used by the `backend-tests` job

## Testing

### Backend Changes

- [ ] Ran `./scripts/run-server-tests.sh` - all tests pass
- [ ] Added/updated tests in `server/tests/` for API changes

### Frontend Changes

- [ ] Ran `./scripts/run-e2e-tests.sh` - all tests pass
- [ ] Added `data-testid` attributes to interactive elements
- [ ] Verified build succeeds in `client/` directory

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have used type hints for Python functions (parameters and return values)
- [ ] I have used Svelte 5 runes syntax (`$state`, `$props`, `$derived`) for components
- [ ] I have followed the dark theme using Tailwind CSS utility classes
- [ ] I have updated documentation (README, instruction files) if needed
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

No application code changed -- this is a CI workflow fix only. The `frontend-lint` job (which only needs Node) is unaffected and continues to use `npm ci` directly, which is appropriate for lint-only work.