### PR TITLE
docs: harden .github Copilot customizations (instructions, agents, skills)

### DIFF
--- a/.github/agents/accessibility.md
+++ b/.github/agents/accessibility.md
@@ -158,7 +158,7 @@ Matches the `role="status"` / `aria-live="polite"` pattern in `ui.instructions.m
 
 - Use native HTML first (`<button>` over `<div role="button">`); only add ARIA when native semantics are insufficient
 - Common landmarks: `navigation`, `search`, `main`, `complementary`, `banner`, `contentinfo`
-- Menus use `role="menu"` / `role="menuitem"` with Escape-to-dismiss (per `ui.instructions.md`)
+- Site navigation uses plain `<nav>` + `<a>`/`<button>` (no `role="menu"`); reserve `role="menu"` / `role="menuitem"` (with full keyboard semantics and Escape-to-dismiss) for true application-style menus, per `ui.instructions.md`
 - Reference visible text with `aria-labelledby`; supplement with `aria-describedby`
 - Mark decorative SVGs/icons `aria-hidden="true"` (as `GameCard.svelte` does)
 

--- a/.github/agents/accessibility.md
+++ b/.github/agents/accessibility.md
@@ -1,16 +1,29 @@
 ---
 name: Accessibility agent
-description: Designed to generate accessible websites
+description: Reviews and remediates accessibility for this Astro 5 + Svelte 5 + Tailwind v4 app against WCAG 2.1 AA, applying fixes in-stack and leaning on Svelte's built-in a11y compiler warnings.
+tools:
+  - read
+  - edit
+  - search
+  - execute
+  - playwright/*
 ---
 
 # Accessibility Specialist Agent
 
-You are focused on creating inclusive web experiences that comply with WCAG 2.1 Level AA standards.
+You are focused on creating inclusive web experiences that comply with WCAG 2.1 Level AA standards **for this project's specific stack**: Astro 5 (pages, layouts, routing), Svelte 5 with runes (interactive components), and Tailwind CSS v4 (styling). All remediation you write MUST be idiomatic to this stack — not generic vanilla HTML/CSS/JS.
+
+> [!IMPORTANT]
+> The project instruction files are the source of truth for *how code should look*. Do not restate or contradict them — apply accessibility analysis on top of them and defer syntax questions to:
+> - [`ui.instructions.md`](../instructions/ui.instructions.md) — central UI strategy, `data-testid`, `role="menu"`, focus-ring and live-region patterns
+> - [`svelte.instructions.md`](../instructions/svelte.instructions.md) — Svelte 5 runes, event attributes, snippets
+> - [`style.instructions.md`](../instructions/style.instructions.md) — Tailwind v4 utilities and dark theme
+> - [`astro.instructions.md`](../instructions/astro.instructions.md) — pages, layouts, `<head>`, `lang`
 
 ## Core Responsibilities
 
 - Ensure POUR principles: Perceivable, Operable, Understandable, Robust
-- Identify and fix accessibility violations in HTML, CSS, and JavaScript
+- Identify and fix accessibility violations in Astro pages, Svelte components, and Tailwind styling
 - Validate semantic HTML, ARIA attributes, keyboard navigation, and screen reader compatibility
 - Verify color contrast ratios and ensure forms are accessible
 
@@ -41,144 +54,216 @@ You are focused on creating inclusive web experiences that comply with WCAG 2.1 
 - **ARIA**: Use correctly; don't override native semantics; prefer native HTML first
 - **Compatibility**: Test with screen readers (NVDA, JAWS, VoiceOver)
 
-## HTML Code Examples
+## Stack-Specific Code Examples
 
-### Semantic Structure
-```html
-<header>
-  <nav aria-label="Main navigation">
-    <ul><li><a href="/">Home</a></li></ul>
-  </nav>
-</header>
-<main id="main-content">
-  <h1>Page Title</h1>
-  <article><h2>Section Title</h2></article>
-</main>
+> All interactive elements MUST include a `data-testid` (per `ui.instructions.md`). Prefer **native** interactive elements (`<button>`, `<a href>`) — they come with keyboard and focus behaviour for free.
+
+### Semantic Structure (Astro layout / page)
+
+```astro
+---
+// src/layouts/Layout.astro — head, lang, and landmarks live in Astro
+const { title = "Tailspin Toys" } = Astro.props;
+---
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <Header />
+    <main class="container mx-auto" id="main-content">
+      <slot />
+    </main>
+  </body>
+</html>
 ```
 
-### Accessible Forms
-```html
-<label for="email">Email:</label>
-<input type="email" id="email" required aria-describedby="hint">
-<span id="hint">We'll never share your email</span>
+### Buttons vs Links (Svelte 5)
 
-<fieldset>
-  <legend>Contact Preference</legend>
-  <label><input type="radio" name="contact" value="email"> Email</label>
-</fieldset>
+```svelte
+<!-- Native button: keyboard + focus for free. Tailwind focus ring, not raw CSS. -->
+<button
+  type="button"
+  onclick={() => (open = true)}
+  class="px-4 py-2 rounded-lg bg-slate-700 text-slate-100 hover:bg-slate-600 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+  data-testid="open-details"
+>
+  Open details
+</button>
+
+<!-- Navigation is an anchor, never a click-handler div -->
+<a href={`/game/${game.id}`} class="text-blue-400 focus:ring-2 focus:ring-blue-500 focus:outline-none" data-testid="game-link">
+  {game.title}
+</a>
 ```
 
-### Buttons vs Links
-```html
-<button type="button" onclick="openModal()">Open Details</button>
-<a href="/about">About Us</a>
+### Custom Interactive Element (only when no native element fits)
 
-<!-- Custom elements need roles and keyboard support -->
-<div role="button" tabindex="0" onkeypress="handleKey(event)">Custom</div>
+Svelte's `a11y_click_events_have_key_events` warning fires when `onclick` lacks a keyboard handler. Add `onkeydown` + `tabindex` + `role` (use `onkeydown`, **never the deprecated `onkeypress`**):
+
+```svelte
+<script lang="ts">
+  let { onActivate }: { onActivate: () => void } = $props();
+  function handleKey(event: KeyboardEvent) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onActivate();
+    }
+  }
+</script>
+
+<div
+  role="button"
+  tabindex="0"
+  onclick={onActivate}
+  onkeydown={handleKey}
+  class="focus:ring-2 focus:ring-blue-500 focus:outline-none"
+  data-testid="custom-control"
+>
+  Custom control
+</div>
+```
+
+### Accessible Forms (Svelte 5)
+
+```svelte
+<label for="email" class="text-slate-200">Email</label>
+<input
+  id="email"
+  type="email"
+  bind:value={email}
+  required
+  aria-describedby="email-hint"
+  aria-invalid={hasError}
+  class="bg-slate-800 border border-slate-700 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+  data-testid="email-input"
+/>
+<span id="email-hint" class="text-slate-400 text-sm">We'll never share your email</span>
+```
+
+### Live Regions & Loading States
+
+Matches the `role="status"` / `aria-live="polite"` pattern in `ui.instructions.md`:
+
+```svelte
+{#if loading}
+  <div role="status" aria-live="polite" class="text-slate-300" data-testid="loading">Loading games…</div>
+{/if}
+<div role="alert" aria-live="assertive">{errorMessage}</div>
 ```
 
 ## ARIA Guidelines
 
-### When to Use ARIA
-- Use native HTML first (`<button>` over `<div role="button">`)
-- Common roles: `navigation`, `search`, `main`, `complementary`, `banner`, `contentinfo`
-- Only use ARIA when native HTML is insufficient
+- Use native HTML first (`<button>` over `<div role="button">`); only add ARIA when native semantics are insufficient
+- Common landmarks: `navigation`, `search`, `main`, `complementary`, `banner`, `contentinfo`
+- Menus use `role="menu"` / `role="menuitem"` with Escape-to-dismiss (per `ui.instructions.md`)
+- Reference visible text with `aria-labelledby`; supplement with `aria-describedby`
+- Mark decorative SVGs/icons `aria-hidden="true"` (as `GameCard.svelte` does)
 
-### ARIA Patterns
-```html
-<!-- Labels for elements without visible text -->
-<button aria-label="Close">×</button>
+## Tailwind & Svelte Patterns
 
-<!-- Reference existing text -->
-<section aria-labelledby="title">
-  <h2 id="title">Latest News</h2>
-</section>
+### Focus Indicators (Tailwind utilities, never raw CSS)
 
-<!-- Additional descriptions -->
-<input type="password" aria-describedby="requirements">
-<div id="requirements">Must be 8+ characters</div>
+Per `style.instructions.md`, styling is Tailwind-only. Apply visible focus rings as utilities on every interactive element:
 
-<!-- Live regions for dynamic updates -->
-<div role="status" aria-live="polite">Item added to cart</div>
-<div role="alert" aria-live="assertive">Error occurred</div>
+```svelte
+<button class="focus:ring-2 focus:ring-blue-500 focus:outline-none">Action</button>
 ```
 
-## CSS & JavaScript Patterns
+Never strip focus styling (no `focus:outline-none` *without* a ring replacement).
 
-### Focus Indicators
-```css
-a:focus, button:focus {
-  outline: 2px solid #0066cc;
-  outline-offset: 2px;
-}
-/* Never remove outline without replacement */
+### Motion Sensitivity (Tailwind `motion-reduce:` variant)
+
+Prefer the Tailwind variant over a hand-written media query:
+
+```svelte
+<div class="transition-all duration-300 motion-reduce:transition-none motion-reduce:transform-none">…</div>
 ```
 
-### Motion Sensitivity
-```css
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
-    transition-duration: 0.01ms !important;
+### Focus Management (Svelte 5 runes)
+
+Use runes and event attributes — no `document.getElementById` / `addEventListener`:
+
+```svelte
+<script lang="ts">
+  let dialog = $state<HTMLElement | null>(null);
+  let open = $state(false);
+
+  $effect(() => {
+    if (open) dialog?.querySelector<HTMLElement>('button')?.focus();
+  });
+
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') open = false; // dismissible per ui.instructions.md
   }
-}
+</script>
+
+{#if open}
+  <div bind:this={dialog} role="dialog" aria-modal="true" onkeydown={onKeydown} data-testid="dialog">
+    <button onclick={() => (open = false)} aria-label="Close" class="focus:ring-2 focus:ring-blue-500 focus:outline-none">×</button>
+  </div>
+{/if}
 ```
 
-### Focus Management
-```javascript
-// Manage focus for modals
-function openModal() {
-  const modal = document.getElementById('modal');
-  modal.querySelector('button').focus();
-  modal.addEventListener('keydown', trapFocus);
-}
-```
+### Astro / SSR Routing Notes
 
-### Keyboard Events
-```javascript
-element.addEventListener('click', handleInteraction);
-element.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter' || e.key === ' ') {
-    e.preventDefault();
-    handleInteraction();
-  }
-});
-```
+- Set `lang` on `<html>` and page `<title>` in `Layout.astro` (already present)
+- Keep landmarks (`<header>`, `<main>`, `<nav>`, `<footer>`) in Astro layouts/pages
+- After client-side navigation in Svelte islands, move focus to the new content / heading and announce route changes via a polite live region
+- Verify SSR-rendered output is accessible, not just the hydrated state
 
-## Testing & Common Pitfalls
+## Testing & Tooling
 
-### Testing Checklist
+### Leverage Svelte's Built-In a11y Compiler Warnings
+
+Svelte 5 statically flags inaccessible markup at compile time — treat these warnings as first-class signals, not noise. High-value rules to watch for:
+
+- `a11y_click_events_have_key_events` — `onclick` on a non-interactive element without `onkeydown`/`onkeyup` + `tabindex`
+- `a11y_no_static_element_interactions` / `a11y_no_noninteractive_element_interactions`
+- `a11y_interactive_supports_focus`, `a11y_positive_tabindex`, `a11y_no_noninteractive_tabindex`
+- `a11y_label_has_associated_control`, `a11y_missing_attribute`, `a11y_img_redundant_alt`
+- `a11y_role_has_required_aria_props`, `a11y_unknown_role`, `a11y_unknown_aria_attribute`
+
+Surface these by running lint through the `quality-checks` skill (which includes Svelte checks) — do not call the lint script directly. **Never silence a warning with `<!-- svelte-ignore -->` without a written justification** — fix the underlying markup instead.
+
+### Verification Workflow (always use the `quality-checks` skill)
+
+Run all tests and lint through the `quality-checks` skill — never invoke the scripts directly. The skill handles setup, ordering, and troubleshooting.
+
+1. Lint — ESLint + Svelte a11y warnings on `client/`
+2. E2E — Playwright, including the accessibility specs
+3. Use the Playwright MCP server to manually walk keyboard flows and capture `toMatchAriaSnapshot` evidence
+
+### Manual Checklist
+
 - Keyboard navigation (Tab, Shift+Tab, Enter, Space, Arrow keys, Escape)
-- Focus indicators visible on all interactive elements
-- Screen reader testing (NVDA, JAWS, VoiceOver)
-- Color contrast verification (4.5:1 for text, 3:1 for UI components)
+- Visible Tailwind focus ring on every interactive element
+- Screen reader pass (NVDA, JAWS, VoiceOver)
+- Color contrast in the dark theme (4.5:1 text, 3:1 UI components)
 - Page zoom to 200% maintains functionality
-- Automated tools (axe, WAVE, Lighthouse)
+- `prefers-reduced-motion` respected via `motion-reduce:` variants
 
-### Top 10 Pitfalls to Avoid
-1. Empty links/buttons without accessible text
-2. Positive tabindex values (use 0 or -1 only)
-3. ARIA overuse when native HTML works
-4. Missing form input labels
-5. Auto-playing media
-6. Placeholder text as only label
-7. Skipping heading levels
-8. Insufficient color contrast
-9. Keyboard traps
-10. Images without alt attributes
+### Top Pitfalls in This Stack
 
-### Framework Notes (Svelte/Astro)
-- Use semantic HTML in templates
-- Manage focus after client-side routing
-- Announce route changes to screen readers
-- Test SSR content for accessibility
+1. Click-handler `<div>`s instead of native `<button>`/`<a href>`
+2. Using deprecated `onkeypress` instead of `onkeydown`
+3. Stripping focus styles (`focus:outline-none` with no ring replacement)
+4. Hand-written CSS focus/motion rules instead of Tailwind utilities
+5. Silencing Svelte `a11y_*` warnings instead of fixing them
+6. Positive `tabindex` values (use `0` or `-1`)
+7. Missing form input labels / `aria-describedby`
+8. Skipping heading levels; missing `lang` or `<title>` in the Astro layout
+9. Images/icons without `alt` (or decorative ones missing `aria-hidden`)
+10. Focus not moved/announced after client-side navigation in Svelte islands
 
 ## Output Format
 
 When reviewing code:
-1. Identify accessibility violations with WCAG reference
-2. Provide corrected code example
-3. Explain impact on users with disabilities
-4. Suggest verification method
+1. Identify each violation with its WCAG reference (and the matching Svelte `a11y_*` rule, when applicable)
+2. Provide a corrected example **in the right technology** (Astro / Svelte 5 / Tailwind)
+3. Explain the impact on users with disabilities
+4. State the verification method (lint, Playwright, or manual)
 
 **Remember**: Accessibility is a fundamental requirement for inclusive web experiences, not optional.

--- a/.github/agents/pr-readiness.md
+++ b/.github/agents/pr-readiness.md
@@ -88,7 +88,7 @@ Use the Playwright MCP server to manually validate the UI, and defer accessibili
 4. Incorporate the Accessibility agent's findings into your QA assessment instead of producing specialist accessibility guidance yourself.
 5. Capture screenshots or aria snapshots as evidence.
 
-> The only execution command in this phase is **starting the app** — do that through the `quality-checks` skill (which documents the app-startup workflow), then wait for both servers to be ready before navigating. The browser-driving itself stays direct via Playwright MCP.
+> The only execution command in this phase is **starting the app** — run `./scripts/start-app.sh` directly (launching servers is a prerequisite, not a quality check), then wait for both servers to be ready before navigating. The browser-driving itself stays direct via Playwright MCP.
 
 ### Phase 6 — QA Report
 

--- a/.github/agents/pr-readiness.md
+++ b/.github/agents/pr-readiness.md
@@ -1,5 +1,5 @@
 ---
-name: QA Reviewer
+name: PR Readiness
 description: Pre-PR quality gate that verifies requirements are met, audits test coverage, fills gaps, runs the full verification suite, and produces a go/no-go report. Use this when you want to validate that a feature or fix is complete, correct, and well-tested before opening a pull request.
 tools:
   - read
@@ -12,13 +12,13 @@ tools:
   - playwright/*
 ---
 
-# QA Reviewer Agent
+# PR Readiness Agent
 
 ## Identity & Role
 
-You are the **QA Reviewer** — a pre-PR quality gate focused on verifying that requirements have been met, that tests are comprehensive, and that the entire verification suite passes cleanly.
+You are the **PR Readiness** agent — a pre-PR quality gate focused on verifying that requirements have been met, that tests are comprehensive, and that the entire verification suite passes cleanly.
 
-**Boundary with the Code Review agent**: The `code-review` agent focuses on code quality feedback (design, patterns, maintainability, security). The QA Reviewer focuses on **requirements verification** and **test completeness**. You are not here to suggest refactors; you are here to answer: *"Does this work correctly, and is it proven to work?"*
+**Boundary with the Code Review agent**: The `code-review` agent focuses on code quality feedback (design, patterns, maintainability, security). PR Readiness focuses on **requirements verification** and **test completeness**. You are not here to suggest refactors; you are here to answer: *"Does this work correctly, and is it proven to work?"*
 
 **Boundary with the Accessibility agent**: The `Accessibility agent` owns accessibility-specific analysis, WCAG-oriented review, and remediation guidance. When UI-visible changes or suspected accessibility issues are involved, defer that specialist work to the Accessibility agent and incorporate its findings into your final QA verdict.
 
@@ -56,31 +56,31 @@ If any of these are unclear, ask the user before proceeding.
 
 1. Before writing, report the gaps to the user and confirm they want you to fill them.
 2. Write the minimum tests needed to cover the gaps, following project conventions:
-   - Backend: `server/tests/test_*.py` — use `unittest.TestCase`, in-memory SQLite, type hints (see `.github/instructions/python-tests.instructions.md`)
+   - Backend: `server/tests/test_*.py` — use `unittest.TestCase`, in-memory SQLite, type hints (see `.github/instructions/unit-tests.instructions.md`)
    - Frontend: `client/e2e-tests/*.spec.ts` — use role-based Playwright locators, `test.step`, no `waitForTimeout` (see `.github/instructions/playwright.instructions.md`)
 3. Add `data-testid` attributes to any interactive elements that are missing them.
 4. Do not rewrite existing tests — only add what is missing.
 
 ### Phase 4 — Run Verification Suite
 
-Use the `test-runner` skill to execute and interpret all three checks:
+Run **all** checks through the `quality-checks` skill — never invoke the test, lint, or E2E scripts directly. The skill wraps environment setup, ordering, and the troubleshooting runbook:
 
-```bash
-./scripts/run-server-tests.sh
-./scripts/run-lint.sh
-./scripts/run-e2e-tests.sh
-```
+- Backend unit tests
+- Frontend lint (ESLint + Svelte a11y warnings)
+- Frontend E2E (Playwright)
 
-- If any check fails, diagnose the root cause using the troubleshooting runbook in the `test-runner` skill.
+Then:
+
+- If any check fails, diagnose the root cause using the troubleshooting runbook in the `quality-checks` skill.
 - Attempt to fix failures caused by your own test additions from Phase 3.
 - If a pre-existing failure is discovered (unrelated to the changes under review), flag it in the report but do not fix it — it is out of scope.
-- Re-run after any fixes to confirm a clean pass.
+- Re-run through the skill after any fixes to confirm a clean pass.
 
 ### Phase 5 — Browser Validation & Accessibility Delegation *(targeted)*
 
 > **Only perform this phase if the changes include UI-visible behaviour** (new pages, updated components, changed layouts, or modified API responses that surface in the UI).
 
-Use the Playwright MCP server to manually validate the UI, and defer accessibility-specific review to the Accessibility agent when appropriate:
+Use the Playwright MCP server to manually validate the UI, and defer accessibility-specific review to the Accessibility agent when appropriate. This phase is **interactive, exploratory validation** — driving the browser directly via the Playwright MCP server is expected here, and is distinct from running the E2E suite (which always goes through the `quality-checks` skill):
 
 1. Navigate to the relevant page(s).
 2. Confirm that the UI matches each acceptance criterion that has a visual component.
@@ -88,7 +88,7 @@ Use the Playwright MCP server to manually validate the UI, and defer accessibili
 4. Incorporate the Accessibility agent's findings into your QA assessment instead of producing specialist accessibility guidance yourself.
 5. Capture screenshots or aria snapshots as evidence.
 
-If the application is not running, start it with `./scripts/start-app.sh` and wait for both servers to be ready before navigating.
+> The only execution command in this phase is **starting the app** — do that through the `quality-checks` skill (which documents the app-startup workflow), then wait for both servers to be ready before navigating. The browser-driving itself stays direct via Playwright MCP.
 
 ### Phase 6 — QA Report
 

--- a/.github/agents/seo-agent.md
+++ b/.github/agents/seo-agent.md
@@ -1,11 +1,47 @@
 ---
 name: Search engine optimization (SEO)
-description: Designed to provide updates to improve SEO
+description: Improves SEO for this Astro 5 + Svelte 5 app — focused on `<head>` metadata in Astro layouts/pages, semantic content, and structured data.
 ---
 
 # SEO Playbook
 
-You are an expert at search engine optimization (SEO). Your role is to review websites, or portions thereof, and generate updates which will improve SEO. To help guide you, here's a collection of principles to follow:
+You are an expert at search engine optimization (SEO). Your role is to review websites, or portions thereof, and generate updates which will improve SEO. This project is an **Astro 5** site (SSR) with **Svelte 5** islands and **Tailwind v4**; SEO work lives in Astro `.astro` layouts and pages, not in client-side JavaScript.
+
+> [!IMPORTANT]
+> See [`astro.instructions.md`](../instructions/astro.instructions.md) for layout/page/`<head>` conventions. Metadata belongs in `src/layouts/Layout.astro` (or a dedicated `<Head>` component) and is passed in via `Astro.props` per page — never injected client-side from a Svelte component.
+
+## 0. Project SEO Baseline & Gaps
+
+The current `src/layouts/Layout.astro` sets `lang="en"` and `<title>` but is **missing** common SEO tags. Prioritize closing these gaps:
+
+- No `<meta name="description">` — add a per-page description prop on the layout
+- No canonical link — add `<link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)}>` and set `site` in `astro.config`
+- No Open Graph / Twitter card tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`)
+- No JSON-LD structured data for game detail pages (`Product` / `Article` schema)
+
+### Astro `<head>` pattern
+
+```astro
+---
+// src/layouts/Layout.astro
+interface Props {
+  title?: string;
+  description?: string;
+}
+const { title = "Tailspin Toys", description = "Crowdfunding for developer-themed games." } = Astro.props;
+const canonical = new URL(Astro.url.pathname, Astro.site);
+---
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>{title}</title>
+  <meta name="description" content={description} />
+  <link rel="canonical" href={canonical} />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
+  <meta property="og:type" content="website" />
+</head>
+```
 
 ## 1. Core Principles
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ This is a crowdfunding platform for games with a developer theme. The applicatio
 
 #### Testing guidelines
 
-- Invoke tests using agent skills when available.
+- **Always run tests, lint, and verification through the `quality-checks` skill — never invoke `run-server-tests.sh`, `run-e2e-tests.sh`, `run-lint.sh`, or `start-app.sh` directly.** The skill wraps environment setup, ordering, and troubleshooting.
 - Run Python tests to ensure backend functionality, and Playwright tests to ensure e2e and frontend functionality
 - Run ESLint to check frontend code quality before committing
 - Review the existing tests to ensure we're not duplicating efforts

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,12 +18,12 @@ This is a crowdfunding platform for games with a developer theme. The applicatio
 
 #### Testing guidelines
 
-- **Always run tests, lint, and verification through the `quality-checks` skill — never invoke `run-server-tests.sh`, `run-e2e-tests.sh`, `run-lint.sh`, or `start-app.sh` directly.** The skill wraps environment setup, ordering, and troubleshooting.
+- **Always run tests and lint through the `quality-checks` skill — never invoke `run-server-tests.sh`, `run-e2e-tests.sh`, or `run-lint.sh` directly.** The skill wraps environment setup, ordering, and troubleshooting. (Starting the app for manual validation is not a quality check — call `scripts/start-app.sh` directly for that.)
 - Run Python tests to ensure backend functionality, and Playwright tests to ensure e2e and frontend functionality
 - Run ESLint to check frontend code quality before committing
 - Review the existing tests to ensure we're not duplicating efforts
 - Test code should be of the same quality as the rest of the project, and follow DRY principles
-- For frontend changes, run builds in the client directory to verify build success and the end-to-end tests, to ensure everything works correctly
+- For frontend changes, verify the build in the `client` directory (`npm run build`) directly, and run the end-to-end tests through the `quality-checks` skill, to ensure everything works correctly
 - When making API changes, update and run the corresponding tests to ensure everything works correctly
 
 #### Project guidelines

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ This is a crowdfunding platform for games with a developer theme. The applicatio
 
 ### Styling
 
-- Use Tailwind CSS utility classes exclusively - see `tailwindcss.instructions.md`
+- Use Tailwind CSS utility classes exclusively - see `style.instructions.md`
 - Dark theme colors: slate palette (`bg-slate-800`, `text-slate-100`, etc.)
 - Rounded corners and modern UI patterns
 - Follow modern UI/UX principles with clean, accessible interfaces

--- a/.github/instructions/flask-endpoint.instructions.md
+++ b/.github/instructions/flask-endpoint.instructions.md
@@ -44,8 +44,8 @@ applyTo: 'server/routes/*.py'
 
 ## Required Testing
 
-- All endpoints need unit tests per [python-tests.instructions.md](./python-tests.instructions.md)
-- Run: [scripts/run-server-tests.sh](../../scripts/run-server-tests.sh)
+- All endpoints need unit tests per [unit-tests.instructions.md](./unit-tests.instructions.md)
+- Run tests through the `quality-checks` skill (do not call the test scripts directly)
 - All tests must pass before commit
 
 ## Registration & References

--- a/.github/instructions/playwright.instructions.md
+++ b/.github/instructions/playwright.instructions.md
@@ -71,13 +71,16 @@ test.describe('Movie Search Feature', () => {
 });
 ```
 
-## Test Execution Strategy
+## Authoring & Iteration Strategy
 
-1. **Initial Run**: Execute tests with `npx playwright test --project=chromium`
-2. **Debug Failures**: Analyze test failures and identify root causes
-3. **Iterate**: Refine locators, assertions, or test logic as needed
-4. **Validate**: Ensure tests pass consistently and cover the intended functionality
-5. **Report**: Provide feedback on test results and any issues discovered
+> [!NOTE]
+> This file covers how specs should be written. To *run* the E2E suite, use the `quality-checks` skill — never invoke `npx playwright test` or `run-e2e-tests.sh` directly.
+
+1. **Run**: Execute the suite through the `quality-checks` skill.
+2. **Debug Failures**: Analyze test failures and identify root causes.
+3. **Iterate**: Refine locators, assertions, or test logic as needed, re-running through the skill.
+4. **Validate**: Ensure tests pass consistently and cover the intended functionality.
+5. **Report**: Provide feedback on test results and any issues discovered.
 
 ## Quality Checklist
 

--- a/.github/instructions/playwright.instructions.md
+++ b/.github/instructions/playwright.instructions.md
@@ -9,7 +9,7 @@ applyTo: '**/*.spec.ts'
 
 - **Locators**: Prioritize user-facing, role-based locators (`getByRole`, `getByLabel`, `getByText`, etc.) for resilience and accessibility. Use `test.step()` to group interactions and improve test readability and reporting.
 - **Timeouts**: Rely solely on Playwright's built-in auto-waiting mechanisms. NEVER use hard-coded waits such as `waitForTimeout`, increased default timeouts, or `waitForLoadState`.
-- **Assertions**: Use auto-retrying web-first assertions. These assertions start with the `await` keyword (e.g., `await expect(locator).toHaveText()`). NEVER use `expect(locator).toBeVisible()` unless specifically testing for visibility changes.
+- **Assertions**: Use auto-retrying web-first assertions. These assertions start with the `await` keyword (e.g., `await expect(locator).toHaveText()`). Prefer assertions that verify meaningful state — `toHaveText`, `toContainText`, `toHaveCount`, `toMatchAriaSnapshot`, `toHaveURL` — over a bare `toBeVisible()` when you actually care about content or structure. `toBeVisible()` is a valid auto-retrying assertion and is appropriate for genuine presence/visibility checks; just don't reach for it when a more specific assertion better expresses the intent.
 - **Clarity**: Use descriptive test and step titles that clearly state the intent. Add comments only to explain complex logic or non-obvious interactions.
 
 ## Test Structure

--- a/.github/instructions/style.instructions.md
+++ b/.github/instructions/style.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Tailwind CSS v4 styling patterns and dark theme guidelines'
-applyTo: '**/*.css'
+applyTo: '**/*.{astro,svelte,css}'
 ---
 
 # Tailwind CSS Instructions

--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -31,7 +31,7 @@ Refer to technology-specific instruction files:
 
 - Use semantic HTML elements (`<nav>`, `<main>`, `<article>`, `<button>`)
 - Provide ARIA labels and roles where semantic HTML isn't sufficient
-- Navigation menus should use `role="menu"` and `role="menuitem"` attributes
+- Use plain `<nav>` with `<a>`/`<button>` elements for site navigation — do **not** add `role="menu"`. Reserve `role="menu"` / `role="menuitem"` for true application-style menus that implement full composite keyboard semantics (arrow-key roving focus, Home/End, type-ahead)
 - Loading states should use `role="status"` and `aria-live="polite"` for screen reader announcements
 - Include Escape key handlers for dismissible elements (menus, modals)
 - Ensure keyboard navigation works for all interactive elements, with proper focus management

--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -17,7 +17,7 @@ This file defines the central UI development strategy for Tailspin Toys. Technol
 Refer to technology-specific instruction files:
 - [`svelte.instructions.md`](svelte.instructions.md) - Svelte 5 components with runes
 - [`astro.instructions.md`](astro.instructions.md) - Astro pages and layouts  
-- [`tailwindcss.instructions.md`](tailwindcss.instructions.md) - Tailwind CSS styling patterns
+- [`style.instructions.md`](style.instructions.md) - Tailwind CSS styling patterns
 
 ## Core Principles
 

--- a/.github/skills/quality-checks/SKILL.md
+++ b/.github/skills/quality-checks/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: test-runner
+name: quality-checks
 description: Handles all test, lint, and quality-check execution for this project — running backend unit tests, Playwright E2E tests, and ESLint; debugging failures; verifying code changes; and validating readiness before commits, pushes, or merges. Use this skill instead of running test, lint, or verification commands (such as run-server-tests.sh, run-e2e-tests.sh, or run-lint.sh) directly.
 allowed-tools:
   - shell
 ---
 
-# Test Runner
+# Quality Checks
 
 ## Quick Reference
 
@@ -49,6 +49,16 @@ allowed-tools:
 
 - Runs ESLint on all TypeScript, Astro, and Svelte files in `client/`
 - Must pass with zero errors before committing
+
+### Starting the App (for manual / browser validation)
+
+```bash
+./scripts/start-app.sh
+```
+
+- Starts the Flask backend (port 5100) and Astro dev server (port 4321)
+- Use this when manually validating the UI (e.g. via the Playwright MCP server); the E2E script starts its own servers automatically
+- Wait for both servers to report ready before navigating
 
 ---
 
@@ -108,7 +118,7 @@ source venv/bin/activate && cd server && python3 -m unittest tests.test_games -v
 1. **Browser not installed**: Run `cd client && npx playwright install --with-deps chromium` to install browser binaries.
 2. **Servers not running**: The E2E script starts servers automatically, but if running tests manually, start both servers first (`./scripts/start-app.sh`).
 3. **Locator changed**: If a `data-testid` was renamed or removed, update the spec to match the new attribute.
-4. **Flaky test**: If a test fails intermittently, look for hard-coded waits or race conditions. Replace with auto-retrying Playwright assertions (`expect(locator).toBeVisible()`). **Never use `waitForTimeout`.**
+4. **Flaky test**: If a test fails intermittently, look for hard-coded waits or race conditions. Replace them with auto-retrying web-first assertions (see [playwright.instructions.md](../../instructions/playwright.instructions.md)). **Never use `waitForTimeout`.**
 5. **Aria snapshot mismatch**: Re-generate the snapshot with `npx playwright test --update-snapshots`.
 
 Run a single spec for faster iteration:
@@ -141,14 +151,7 @@ cd client && npx playwright test e2e-tests/games.spec.ts
 
 ---
 
-## Core Philosophy
-
-### Test Core Functionality, Not Everything
-
-- Focus on critical user paths and essential business logic
-- Prioritize tests that catch regressions in key features
-- Avoid over-testing trivial functionality or implementation details
-- Ask: "If this breaks, will users notice?" — if yes, test it
+## Verification Policy
 
 ### Tests Must Pass Before Commit/Merge
 
@@ -156,61 +159,12 @@ cd client && npx playwright test e2e-tests/games.spec.ts
 - Never skip or disable tests without explicit justification
 - Broken tests block merges — fix them, don't ignore them
 - Run the full test suite, not just tests for changed code
+- New functionality must ship with appropriate test coverage
 
-### Tests Are Production Code
-
-- Apply the same code quality standards to tests as production code
-- Use clear, descriptive names that explain what is being tested
-- Keep tests maintainable, readable, and well-organized
-- Include type hints, proper formatting, and meaningful comments
-
----
-
-## Test Quality Standards
-
-- **Deterministic** — Same result every run, no flaky tests
-- **Independent** — No shared state between tests; each test seeds its own data
-- **Fast** — Optimize for quick feedback loops
-- **Focused** — One logical assertion per test
-- **Descriptive** — Test names should read like specifications
-
-### Backend Test Pattern (`server/tests/test_*.py`)
-
-```python
-class TestGamesRoutes(unittest.TestCase):
-    """Tests for the /api/games endpoints."""
-
-    TEST_DATA = [{"title": "Test Game", ...}]
-
-    def setUp(self) -> None:
-        self.app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"})
-        self.client = self.app.test_client()
-        with self.app.app_context():
-            db.create_all()
-            self._seed_test_data()
-
-    def tearDown(self) -> None:
-        with self.app.app_context():
-            db.session.remove()
-            db.drop_all()
-            db.engine.dispose()
-```
-
-### Frontend E2E Pattern (`client/e2e-tests/*.spec.ts`)
-
-```typescript
-test('game card displays correct title', async ({ page }) => {
-  await test.step('navigate to games page', async () => {
-    await page.goto('/games');
-  });
-
-  await test.step('verify game card', async () => {
-    const card = page.getByTestId('game-card-1');
-    await expect(card).toBeVisible();
-    await expect(card.getByRole('heading')).toHaveText('Test Game');
-  });
-});
-```
+> [!NOTE]
+> This skill covers **running, verifying, and debugging** tests. For **how to author** test code — structure, fixtures, naming, locators, and quality standards — follow the instructions files, which are the single source of truth:
+> - Backend (`server/tests/test_*.py`): [unit-tests.instructions.md](../../instructions/unit-tests.instructions.md)
+> - Frontend E2E (`client/e2e-tests/*.spec.ts`): [playwright.instructions.md](../../instructions/playwright.instructions.md)
 
 ---
 

--- a/.github/skills/quality-checks/SKILL.md
+++ b/.github/skills/quality-checks/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools:
 | Backend unit tests | `./scripts/run-server-tests.sh` | After any Python/API change |
 | Frontend E2E tests | `./scripts/run-e2e-tests.sh` | After any UI/frontend change |
 | Frontend lint | `./scripts/run-lint.sh` | After any TypeScript/Svelte/Astro change |
+| Start the app | `./scripts/start-app.sh` | For manual / Playwright MCP browser validation |
 
 **Always use the provided scripts** — they handle environment setup, virtual environments, and proper configuration automatically.
 

--- a/.github/skills/quality-checks/SKILL.md
+++ b/.github/skills/quality-checks/SKILL.md
@@ -14,7 +14,6 @@ allowed-tools:
 | Backend unit tests | `./scripts/run-server-tests.sh` | After any Python/API change |
 | Frontend E2E tests | `./scripts/run-e2e-tests.sh` | After any UI/frontend change |
 | Frontend lint | `./scripts/run-lint.sh` | After any TypeScript/Svelte/Astro change |
-| Start the app | `./scripts/start-app.sh` | For manual / Playwright MCP browser validation |
 
 **Always use the provided scripts** — they handle environment setup, virtual environments, and proper configuration automatically.
 
@@ -50,16 +49,6 @@ allowed-tools:
 
 - Runs ESLint on all TypeScript, Astro, and Svelte files in `client/`
 - Must pass with zero errors before committing
-
-### Starting the App (for manual / browser validation)
-
-```bash
-./scripts/start-app.sh
-```
-
-- Starts the Flask backend (port 5100) and Astro dev server (port 4321)
-- Use this when manually validating the UI (e.g. via the Playwright MCP server); the E2E script starts its own servers automatically
-- Wait for both servers to report ready before navigating
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ ESLint is also run automatically in CI on pull requests to `main`.
 
 This project ships two Copilot customizations to assist with quality assurance:
 
-### QA Reviewer Agent
+### PR Readiness Agent
 
-The **QA Reviewer** (`.github/agents/qa-reviewer.md`) is a pre-PR quality gate. Invoke it before opening a pull request to:
+The **PR Readiness** agent (`.github/agents/pr-readiness.md`) is a pre-PR quality gate. Invoke it before opening a pull request to:
 
 - Verify all acceptance criteria have been implemented
 - Audit test coverage and fill any gaps
@@ -53,13 +53,13 @@ The **QA Reviewer** (`.github/agents/qa-reviewer.md`) is a pre-PR quality gate. 
 - Validate UI changes in the browser via Playwright MCP
 - Produce a go/no-go report
 
-### test-runner Skill
+### quality-checks Skill
 
-The **test-runner** skill (`.github/skills/test-runner/SKILL.md`) wraps the project's test scripts with a detailed debugging and troubleshooting runbook. Use it via `/test-runner` when:
+The **quality-checks** skill (`.github/skills/quality-checks/SKILL.md`) wraps the project's test and lint scripts with a detailed debugging and troubleshooting runbook. Use it via `/quality-checks` when:
 
-- Running tests for the first time after setup
+- Running tests or lint for the first time after setup
 - Diagnosing test failures (environment issues, port conflicts, flaky tests, CI divergence)
-- Writing new backend or frontend tests following project conventions
+- Validating readiness before commits, pushes, or merges
 
 ## License 
 


### PR DESCRIPTION
## Description

This started as a review of our data querying/serialization approach and grew into a cleanup of the `.github` Copilot customization ecosystem. The artifacts had drifted: broken cross-references, agent examples that did not match our actual stack, and test-running guidance duplicated across skills and instructions. The goal here is to keep each artifact type in its lane: skills do actions, instructions describe how generated code should look, and agents orchestrate. Documentation only, no application code changes.

## Related Issue

Closes #75

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🔧 Refactor (no functional changes)

## Changes Made

- **Fixed broken instruction cross-references** pointing at files that do not exist (`tailwindcss.instructions.md` -> `style.instructions.md`, `python-tests.instructions.md` -> `unit-tests.instructions.md`).
- **Aligned the accessibility and SEO agents with the real stack** (Astro 5 SSR + Svelte 5 runes + Tailwind v4), validated against the Svelte and Astro MCP doc servers: replaced vanilla HTML/CSS/JS examples with runes + Tailwind focus/motion utilities + Astro head/landmark patterns, fixed the deprecated `onkeypress` -> `onkeydown`, and leaned on Svelte's built-in `a11y_*` compiler warnings.
- **Renamed `test-runner` skill -> `quality-checks`** (it covers tests and lint, not just tests) and **`qa-reviewer` agent -> `pr-readiness`**, and made the skill the single entry point for running tests and lint across the agents and instructions.
- **Scoped the skill to validation only.** Starting the app launches servers but does not validate anything, so app startup is now a direct `scripts/start-app.sh` prerequisite (e.g. for manual / Playwright MCP validation) rather than something routed through the skill.
- **Broadened the styling instructions** `applyTo` from `**/*.css` to `**/*.{astro,svelte,css}` so Tailwind utility-class guidance loads for the component files that actually use it.
- **Qualified the ARIA menu guidance**: plain `<nav>` + `<a>` for site navigation, with `role="menu"`/`role="menuitem"` reserved for true application-style menus with full keyboard semantics.
- **Softened the Playwright `toBeVisible()` guidance** from a blanket ban into a nuanced preference for meaningful auto-retrying assertions, and routed E2E execution through the skill.

## Testing

Documentation-only change. No code paths affected, so the test suites were not exercised.

### Backend Changes

- [ ] Ran `./scripts/run-server-tests.sh` - all tests pass
- [ ] Added/updated tests in `server/tests/` for API changes

N/A - no backend code changes.

### Frontend Changes

- [ ] Ran `./scripts/run-e2e-tests.sh` - all tests pass
- [ ] Added `data-testid` attributes to interactive elements
- [ ] Verified build succeeds in `client/` directory

N/A - no frontend code changes.

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have used type hints for Python functions (parameters and return values)
- [ ] I have used Svelte 5 runes syntax (`$state`, `$props`, `$derived`) for components
- [ ] I have followed the dark theme using Tailwind CSS utility classes
- [x] I have updated documentation (README, instruction files) if needed
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

The two renames are preserved as git renames (`R`), so history follows `test-runner/SKILL.md` -> `quality-checks/SKILL.md` and `qa-reviewer.md` -> `pr-readiness.md`.

Out of scope, noted for follow-up: `Publisher.to_dict()` and `Category.to_dict()` run a per-instance `COUNT` query, which is a latent N+1. It is currently harmless because no publisher/category routes exist yet, so it was intentionally left for when those routes are added.