### PR TITLE
Add persisted light mode toggle and switch-style theme control

### DIFF
--- a/client/e2e-tests/home.spec.ts
+++ b/client/e2e-tests/home.spec.ts
@@ -24,4 +24,21 @@ test.describe('Home Page', () => {
     // Check that the welcome message is present using more specific locator
     await expect(page.getByText('Find your next game! And maybe even back one! Explore our collection!')).toBeVisible();
   });
+
+  test('should persist theme preference after reload', async ({ page }) => {
+    const toggle = page.getByTestId('theme-toggle-button');
+    const initialTheme = await page.evaluate(() => document.documentElement.dataset.theme ?? 'dark');
+    const expectedTheme = initialTheme === 'light' ? 'dark' : 'light';
+
+    await toggle.click();
+    await expect
+      .poll(async () => page.evaluate(() => document.documentElement.dataset.theme))
+      .toBe(expectedTheme);
+
+    await page.reload();
+
+    await expect
+      .poll(async () => page.evaluate(() => document.documentElement.dataset.theme))
+      .toBe(expectedTheme);
+  });
 });

--- a/client/src/components/Header.astro
+++ b/client/src/components/Header.astro
@@ -20,10 +20,68 @@
       </div>
       <div class="text-xl font-bold"><a href="/" class="hover:underline">Tailspin Toys</a></div>
     </div>
+    <button
+      id="theme-toggle"
+      type="button"
+      data-testid="theme-toggle-button"
+      class="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-2 py-1 text-xs font-medium transition-colors duration-200 hover:bg-white/20 focus:ring-2 focus:ring-white focus:outline-none"
+      role="switch"
+      aria-checked="false"
+      aria-label="Switch to light mode"
+    >
+      <span
+        id="theme-toggle-track"
+        aria-hidden="true"
+        class="relative h-5 w-9 rounded-full bg-white/30 transition-colors duration-200"
+      >
+        <span
+          id="theme-toggle-thumb"
+          class="absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform duration-200"
+        ></span>
+      </span>
+      <span id="theme-toggle-label">Dark</span>
+    </button>
   </div>
 </header>
 
 <script>
+  const themeToggle = document.getElementById('theme-toggle');
+  const themeToggleLabel = document.getElementById('theme-toggle-label');
+  const themeToggleTrack = document.getElementById('theme-toggle-track');
+  const themeToggleThumb = document.getElementById('theme-toggle-thumb');
+  const themeStorageKey = 'tailspin-theme';
+
+  const applyTheme = (theme) => {
+    const isDark = theme === 'dark';
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.classList.toggle('dark', isDark);
+    document.documentElement.style.colorScheme = theme;
+
+    if (themeToggle && themeToggleLabel) {
+      themeToggle.setAttribute('aria-checked', String(!isDark));
+      themeToggle.setAttribute('aria-label', isDark ? 'Switch to light mode' : 'Switch to dark mode');
+      themeToggleLabel.textContent = isDark ? 'Dark' : 'Light';
+    }
+
+    if (themeToggleTrack && themeToggleThumb) {
+      themeToggleTrack.classList.toggle('bg-white/30', isDark);
+      themeToggleTrack.classList.toggle('bg-blue-300/90', !isDark);
+      themeToggleThumb.classList.toggle('translate-x-0', isDark);
+      themeToggleThumb.classList.toggle('translate-x-4', !isDark);
+    }
+  };
+
+  const currentTheme = document.documentElement.dataset.theme === 'light' ? 'light' : 'dark';
+  applyTheme(currentTheme);
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const nextTheme = document.documentElement.dataset.theme === 'light' ? 'dark' : 'light';
+      applyTheme(nextTheme);
+      localStorage.setItem(themeStorageKey, nextTheme);
+    });
+  }
+
   // Toggle menu visibility when hamburger is clicked
   const menuToggle = document.getElementById('menu-toggle');
   const menu = document.getElementById('menu');

--- a/client/src/layouts/Layout.astro
+++ b/client/src/layouts/Layout.astro
@@ -10,19 +10,27 @@ const { title = "Tailspin Toys" } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />
         <title>{title}</title>
+        <script is:inline>
+            const themeStorageKey = "tailspin-theme";
+            const savedTheme = localStorage.getItem(themeStorageKey);
+            const initialTheme = savedTheme === "light" || savedTheme === "dark" ? savedTheme : "dark";
+            document.documentElement.dataset.theme = initialTheme;
+            document.documentElement.classList.toggle("dark", initialTheme === "dark");
+            document.documentElement.style.colorScheme = initialTheme;
+        </script>
         <!-- Preconnect to improve font loading -->
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     </head>
-    <body class="min-h-screen bg-slate-900 text-white transition-colors duration-300 m-0 w-full h-full font-sans">
+    <body class="min-h-screen bg-slate-900 text-slate-100 transition-colors duration-300 m-0 w-full h-full font-sans">
         <Header />
         <main class="container mx-auto py-6 h-full max-w-7xl">
             <div class="px-4 sm:px-6 lg:px-8">

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -1,1 +1,85 @@
 @import "tailwindcss";
+
+:root {
+  color-scheme: dark;
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+}
+
+html[data-theme='light'] .bg-slate-900 {
+  background-color: rgb(248 250 252) !important;
+}
+
+html[data-theme='light'] .bg-slate-800 {
+  background-color: rgb(241 245 249) !important;
+}
+
+html[data-theme='light'] .bg-slate-700 {
+  background-color: rgb(226 232 240) !important;
+}
+
+html[data-theme='light'] .bg-slate-600 {
+  background-color: rgb(203 213 225) !important;
+}
+
+html[data-theme='light'] .bg-slate-100 {
+  background-color: rgb(226 232 240) !important;
+}
+
+html[data-theme='light'] .bg-slate-800\/70 {
+  background-color: rgb(241 245 249 / 0.85) !important;
+}
+
+html[data-theme='light'] .bg-slate-800\/60 {
+  background-color: rgb(241 245 249 / 0.8) !important;
+}
+
+html[data-theme='light'] .bg-slate-800\/50 {
+  background-color: rgb(241 245 249 / 0.72) !important;
+}
+
+html[data-theme='light'] .text-white {
+  color: rgb(15 23 42) !important;
+}
+
+html[data-theme='light'] .text-slate-100 {
+  color: rgb(15 23 42) !important;
+}
+
+html[data-theme='light'] .text-slate-200 {
+  color: rgb(30 41 59) !important;
+}
+
+html[data-theme='light'] .text-slate-300 {
+  color: rgb(51 65 85) !important;
+}
+
+html[data-theme='light'] .text-slate-400 {
+  color: rgb(71 85 105) !important;
+}
+
+html[data-theme='light'] .border-slate-700 {
+  border-color: rgb(148 163 184) !important;
+}
+
+html[data-theme='light'] .border-slate-600 {
+  border-color: rgb(148 163 184) !important;
+}
+
+html[data-theme='light'] .border-slate-700\/50 {
+  border-color: rgb(148 163 184 / 0.45) !important;
+}
+
+html[data-theme='light'] .hover\:bg-slate-700:hover {
+  background-color: rgb(226 232 240) !important;
+}
+
+html[data-theme='light'] .hover\:bg-slate-600:hover {
+  background-color: rgb(203 213 225) !important;
+}
+
+html[data-theme='light'] .hover\:bg-slate-100:hover {
+  background-color: rgb(226 232 240) !important;
+}


### PR DESCRIPTION
## Description

This change adds a user-selectable light mode option while keeping dark mode as the default. It introduces a switch-style theme toggle in the header, applies the selected theme early in the shared layout to avoid flicker, and persists preference in `localStorage` so users keep their choice across visits.

## Related Issue

Closes #77

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🧪 Test update
- [ ] 🔧 Refactor (no functional changes)

## Changes Made

- Added theme bootstrap logic in `client/src/layouts/Layout.astro` that reads `tailspin-theme` and applies `data-theme`, `dark` class, and `color-scheme` before render.
- Added a switch-style theme toggle in `client/src/components/Header.astro` with proper `role="switch"` and `aria-checked` updates.
- Added light-mode CSS overrides in `client/src/styles/global.css` for existing Tailwind slate utility usage across pages/components.
- Added a persistence test in `client/e2e-tests/home.spec.ts` to verify theme preference survives reload.

## Testing

### Backend Changes

- [x] Ran `./scripts/run-server-tests.sh` - all tests pass
- [ ] Added/updated tests in `server/tests/` for API changes

### Frontend Changes

- [ ] Ran `./scripts/run-e2e-tests.sh` - all tests pass
- [x] Added `data-testid` attributes to interactive elements
- [x] Verified build succeeds in `client/` directory

## Checklist

- [x] My code follows the project's coding standards
- [x] I have used type hints for Python functions (parameters and return values)
- [x] I have used Svelte 5 runes syntax (`$state`, `$props`, `$derived`) for components
- [x] I have followed the dark theme using Tailwind CSS utility classes
- [ ] I have updated documentation (README, instruction files) if needed
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

`./scripts/run-e2e-tests.sh` still reports pre-existing accessibility color-contrast failures in `client/e2e-tests/accessibility.spec.ts` (home/about/game details). The new home persistence spec passes.