### PR TITLE
Add recent perused games breadcrumb to home page

### DIFF
--- a/client/e2e-tests/games.spec.ts
+++ b/client/e2e-tests/games.spec.ts
@@ -100,6 +100,22 @@ test.describe('Game Listing and Navigation', () => {
     });
   });
 
+  test('should show recently perused games on the home page', async ({ page }) => {
+    await test.step('Navigate to a game details page to peruse a game', async () => {
+      await page.goto('/game/1');
+      await expect(page.getByTestId('game-details')).toBeVisible();
+      await expect(page.getByTestId('game-details-title')).not.toBeEmpty();
+    });
+
+    await test.step('Navigate back to home page and verify recently perused list', async () => {
+      await page.goto('/');
+      const recentGamesBreadcrumb = page.getByTestId('recent-games-breadcrumb');
+      await expect(recentGamesBreadcrumb).toBeVisible();
+      await expect(page.getByTestId('recent-games-list')).toBeVisible();
+      await expect(page.getByTestId('recent-game-link-1')).toBeVisible();
+    });
+  });
+
   test('should be able to navigate back to home from game details', async ({ page }) => {
     await test.step('Navigate to game details page', async () => {
       await page.goto('/game/1');

--- a/client/src/components/GameDetails.svelte
+++ b/client/src/components/GameDetails.svelte
@@ -2,6 +2,7 @@
     import { onMount } from "svelte";
     import type { Game } from '../types/game';
     import { API_ENDPOINTS } from '../config/api';
+    import { addRecentPerusedGame } from '../utils/recent-games';
     import ErrorMessage from "./ErrorMessage.svelte";
 
     let { game = undefined, gameId = 0 }: { game?: Game, gameId?: number } = $props();
@@ -14,6 +15,7 @@
         // If game object is provided directly, use it
         if (game) {
             gameData = game;
+            addRecentPerusedGame(game);
             loading = false;
             return;
         }
@@ -23,7 +25,9 @@
             try {
                 const response = await fetch(API_ENDPOINTS.gameById(gameId));
                 if (response.ok) {
-                    gameData = await response.json();
+                    const fetchedGame: Game = await response.json();
+                    gameData = fetchedGame;
+                    addRecentPerusedGame(fetchedGame);
                 } else {
                     error = `Failed to fetch game: ${response.status} ${response.statusText}`;
                 }

--- a/client/src/components/RecentGamesBreadcrumb.svelte
+++ b/client/src/components/RecentGamesBreadcrumb.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+    import { getRecentPerusedGames, type RecentPerusedGame } from '../utils/recent-games';
+
+    let recentGames = $state<RecentPerusedGame[]>([]);
+
+    onMount(() => {
+        recentGames = getRecentPerusedGames();
+    });
+</script>
+
+<div class="rounded-xl border border-slate-700 bg-slate-800/60 p-5 shadow-lg" data-testid="recent-games-breadcrumb">
+    <h2 class="text-lg font-semibold text-slate-100">Recently Perused</h2>
+
+    {#if recentGames.length === 0}
+        <p class="mt-3 text-sm text-slate-400" data-testid="recent-games-empty">
+            Peruse a few games and they&apos;ll show up here.
+        </p>
+    {:else}
+        <nav class="mt-4" aria-label="Recently perused games breadcrumb">
+            <ol class="space-y-2" data-testid="recent-games-list">
+                {#each recentGames as recentGame, index (recentGame.id)}
+                    <li class="flex items-center gap-2 text-sm text-slate-300">
+                        {#if index > 0}
+                            <span aria-hidden="true" class="text-slate-500">›</span>
+                        {/if}
+                        <a
+                            href={`/game/${recentGame.id}`}
+                            class="truncate font-semibold text-blue-300 transition-colors duration-200 hover:text-blue-200 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                            data-testid={`recent-game-link-${recentGame.id}`}
+                        >
+                            {recentGame.title}
+                        </a>
+                    </li>
+                {/each}
+            </ol>
+        </nav>
+    {/if}
+</div>

--- a/client/src/pages/index.astro
+++ b/client/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import GameList from '../components/GameList.svelte';
+import RecentGamesBreadcrumb from '../components/RecentGamesBreadcrumb.svelte';
 ---
 
 <Layout title="Tailspin Toys - Crowdfunding your new favorite game!">
@@ -9,7 +10,15 @@ import GameList from '../components/GameList.svelte';
       <h1 class="text-4xl font-bold mb-4 text-slate-100">Welcome to Tailspin Toys</h1>
       <p class="text-xl text-slate-300">Find your next game! And maybe even back one! Explore our collection!</p>
     </div>
-    
-    <GameList client:load />
+
+    <div class="grid grid-cols-1 gap-8 lg:grid-cols-4">
+      <aside class="order-1 lg:order-2 lg:col-span-1">
+        <RecentGamesBreadcrumb client:load />
+      </aside>
+
+      <div class="order-2 lg:order-1 lg:col-span-3">
+        <GameList client:load />
+      </div>
+    </div>
   </div>
 </Layout>

--- a/client/src/utils/recent-games.ts
+++ b/client/src/utils/recent-games.ts
@@ -1,0 +1,53 @@
+import type { Game } from '../types/game';
+
+export interface RecentPerusedGame {
+    id: number;
+    title: string;
+}
+
+const RECENT_PERUSED_GAMES_STORAGE_KEY = 'tailspin-recent-perused-games';
+const RECENT_PERUSED_GAMES_LIMIT = 5;
+
+function isRecentPerusedGame(value: unknown): value is RecentPerusedGame {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    const maybeGame = value as { id?: unknown; title?: unknown };
+    return typeof maybeGame.id === 'number' && typeof maybeGame.title === 'string';
+}
+
+export function getRecentPerusedGames(): RecentPerusedGame[] {
+    if (typeof window === 'undefined') {
+        return [];
+    }
+
+    const storedValue = window.localStorage.getItem(RECENT_PERUSED_GAMES_STORAGE_KEY);
+    if (!storedValue) {
+        return [];
+    }
+
+    try {
+        const parsedValue: unknown = JSON.parse(storedValue);
+        if (!Array.isArray(parsedValue)) {
+            return [];
+        }
+
+        return parsedValue.filter(isRecentPerusedGame).slice(0, RECENT_PERUSED_GAMES_LIMIT);
+    } catch (error) {
+        console.error('Unable to parse recent perused games from localStorage', error);
+        return [];
+    }
+}
+
+export function addRecentPerusedGame(game: Pick<Game, 'id' | 'title'>): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    const dedupedRecentGames = getRecentPerusedGames().filter((recentGame) => recentGame.id !== game.id);
+    const nextRecentGames: RecentPerusedGame[] = [{ id: game.id, title: game.title }, ...dedupedRecentGames]
+        .slice(0, RECENT_PERUSED_GAMES_LIMIT);
+
+    window.localStorage.setItem(RECENT_PERUSED_GAMES_STORAGE_KEY, JSON.stringify(nextRecentGames));
+}


### PR DESCRIPTION
## Description

This improves navigation continuity for users who browse into a game and return home. It adds a lightweight recent-history breadcrumb so recently viewed games are easier to rediscover.

## Related Issue

Closes #81

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🧪 Test update
- [ ] 🔧 Refactor (no functional changes)

## Changes Made

- Added `client/src/utils/recent-games.ts` to manage a localStorage-backed recent-game list (deduped, recency-ordered, capped at 5).
- Updated `GameDetails.svelte` to record each viewed game in recent history.
- Added `RecentGamesBreadcrumb.svelte` to render recent games as linked breadcrumb-style entries.
- Updated `index.astro` layout to keep the panel on the right for large screens and place it higher on small screens for discoverability.
- Added an E2E test that verifies recent-game history appears on the home page after visiting a game.

## Testing

### Backend Changes

- [x] Ran `./scripts/run-server-tests.sh` - all tests pass
- [ ] Added/updated tests in `server/tests/` for API changes

### Frontend Changes

- [x] Ran `./scripts/run-e2e-tests.sh` - all tests pass
- [x] Added `data-testid` attributes to interactive elements
- [x] Verified build succeeds in `client/` directory

## Checklist

- [x] My code follows the project's coding standards
- [x] I have used type hints for Python functions (parameters and return values)
- [x] I have used Svelte 5 runes syntax (`$state`, `$props`, `$derived`) for components
- [x] I have followed the dark theme using Tailwind CSS utility classes
- [x] I have updated documentation (README, instruction files) if needed
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

- Recent history is intentionally client-side only (browser localStorage).
- No backend API or schema changes were required.