### PR TITLE
Require Playwright MCP validation in PR readiness

### DIFF
--- a/.github/agents/pr-readiness.md
+++ b/.github/agents/pr-readiness.md
@@ -76,17 +76,19 @@ Then:
 - If a pre-existing failure is discovered (unrelated to the changes under review), flag it in the report but do not fix it — it is out of scope.
 - Re-run through the skill after any fixes to confirm a clean pass.
 
-### Phase 5 — Browser Validation & Accessibility Delegation *(targeted)*
+### Phase 5 — Browser Validation & Accessibility Delegation *(required)*
 
-> **Only perform this phase if the changes include UI-visible behaviour** (new pages, updated components, changed layouts, or modified API responses that surface in the UI).
+> **Always perform this phase for every PR Readiness run.** Manual validation through the Playwright MCP server is mandatory and must cover the feature or fix under review.
 
-Use the Playwright MCP server to manually validate the UI, and defer accessibility-specific review to the Accessibility agent when appropriate. This phase is **interactive, exploratory validation** — driving the browser directly via the Playwright MCP server is expected here, and is distinct from running the E2E suite (which always goes through the `quality-checks` skill):
+Use the Playwright MCP server to manually validate the implemented feature, and defer accessibility-specific review to the Accessibility agent when appropriate. This phase is **interactive, exploratory validation** — driving the browser directly via the Playwright MCP server is required here, and is distinct from running the E2E suite (which always goes through the `quality-checks` skill):
 
-1. Navigate to the relevant page(s).
-2. Confirm that the UI matches each acceptance criterion that has a visual component.
-3. If the change introduces or modifies interactive UI, forms, focus management, dialog behavior, navigation, or other accessibility-sensitive flows, invoke the `Accessibility agent` to perform the accessibility review.
-4. Incorporate the Accessibility agent's findings into your QA assessment instead of producing specialist accessibility guidance yourself.
-5. Capture screenshots or aria snapshots as evidence.
+1. Start the app with `./scripts/start-app.sh` and wait for both servers to be ready.
+2. Navigate to the relevant page(s) or flow entry point(s).
+3. Execute the feature flow end-to-end in the browser and confirm behavior against the acceptance criteria.
+4. If any acceptance criterion is non-visual, still validate the resulting user-observable outcome in the browser (for example: updated data shown in UI, success/error states, navigation state, or content changes).
+5. If the change introduces or modifies interactive UI, forms, focus management, dialog behavior, navigation, or other accessibility-sensitive flows, invoke the `Accessibility agent` to perform the accessibility review.
+6. Incorporate the Accessibility agent's findings into your QA assessment instead of producing specialist accessibility guidance yourself.
+7. Capture screenshots or aria snapshots as evidence.
 
 > The only execution command in this phase is **starting the app** — run `./scripts/start-app.sh` directly (launching servers is a prerequisite, not a quality check), then wait for both servers to be ready before navigating. The browser-driving itself stays direct via Playwright MCP.
 
@@ -124,7 +126,7 @@ Produce a structured report using the format below. **End with an explicit go/no
 
 ### Browser Validation
 
-*(Included only for UI-affecting changes)*
+*(Required for every PR Readiness run via Playwright MCP)*
 
 - Page/feature tested:
 - Result: ✅ Matches spec / ❌ Mismatch
@@ -158,4 +160,5 @@ Produce a structured report using the format below. **End with an explicit go/no
 - **Don't mark a criterion ✅ if you're unsure** — flag it as ⚠️ Partial and explain
 - **Don't fix unrelated pre-existing issues** — flag them but stay in scope
 - **Don't skip browser validation for UI changes** — visual regressions are real bugs
+- **Don't skip Playwright MCP manual validation for any feature** — every PR Readiness run requires it
 - **Don't perform deep accessibility review yourself for UI changes** — defer that specialist work to the Accessibility agent and use its findings in your report

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The **PR Readiness** agent (`.github/agents/pr-readiness.md`) is a pre-PR qualit
 - Verify all acceptance criteria have been implemented
 - Audit test coverage and fill any gaps
 - Run the full verification suite (unit tests, lint, E2E tests)
-- Validate UI changes in the browser via Playwright MCP
+- Manually validate the feature in the browser via Playwright MCP (required for every run)
 - Produce a go/no-go report
 
 ### quality-checks Skill


### PR DESCRIPTION
## Description

This updates the PR Readiness guidance so manual Playwright MCP validation is always required, not only for explicitly UI-focused changes. The goal is to ensure every PR readiness run includes real browser-level verification of the implemented feature flow.

## Related Issue

N/A (no linked issue was provided for this change).

Closes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🧪 Test update
- [ ] 🔧 Refactor (no functional changes)

## Changes Made

- Updated `.github/agents/pr-readiness.md` Phase 5 from targeted to required.
- Added explicit mandatory Playwright MCP manual validation steps, including end-to-end feature flow validation and evidence capture.
- Updated the Browser Validation report section to be required for every PR readiness run.
- Added an anti-pattern rule that explicitly forbids skipping Playwright MCP manual validation.
- Updated `README.md` to reflect that Playwright MCP manual validation is required on every PR Readiness run.

## Testing

This is a docs/guidance-only change; no runtime behavior changed.

### Backend Changes

- [ ] Ran `./scripts/run-server-tests.sh` - all tests pass
- [ ] Added/updated tests in `server/tests/` for API changes

### Frontend Changes

- [ ] Ran `./scripts/run-e2e-tests.sh` - all tests pass
- [ ] Added `data-testid` attributes to interactive elements
- [ ] Verified build succeeds in `client/` directory

## Checklist

- [x] My code follows the project's coding standards
- [x] I have used type hints for Python functions (parameters and return values)
- [x] I have used Svelte 5 runes syntax (`$state`, `$props`, `$derived`) for components
- [x] I have followed the dark theme using Tailwind CSS utility classes
- [x] I have updated documentation (README, instruction files) if needed
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

This PR intentionally tightens agent behavior so browser-driven validation is always part of PR readiness evidence, even when acceptance criteria include non-visual outcomes surfaced in the UI.