### PR TITLE
Add recent games breadcrumb trail

### DIFF
--- a/client/e2e-tests/games.spec.ts
+++ b/client/e2e-tests/games.spec.ts
@@ -100,8 +100,8 @@ test.describe('Game Listing and Navigation', () => {
     });
   });
 
-  test('should show recently perused games on the home page', async ({ page }) => {
-    await test.step('Navigate to a game details page to peruse a game', async () => {
+  test('should show recently visited games on the home page', async ({ page }) => {
+    await test.step('Navigate to a game details page to visit a game', async () => {
       await page.goto('/game/1');
       await expect(page.getByTestId('game-details')).toBeVisible();
       await expect(page.getByTestId('game-details-title')).not.toBeEmpty();
@@ -113,6 +113,34 @@ test.describe('Game Listing and Navigation', () => {
       await expect(recentGamesBreadcrumb).toBeVisible();
       await expect(page.getByTestId('recent-games-list')).toBeVisible();
       await expect(page.getByTestId('recent-game-link-1')).toBeVisible();
+    });
+  });
+
+  test('should show the five most recently visited games in breadcrumb order', async ({ page }) => {
+    const visitedTitles: string[] = [];
+
+    await test.step('Visit six game details pages in sequence', async () => {
+      for (const gameId of [1, 2, 3, 4, 5, 6]) {
+        await page.goto(`/game/${gameId}`);
+        await expect(page.getByTestId('game-details')).toBeVisible();
+
+        const gameTitle = await page.getByTestId('game-details-title').textContent();
+        if (gameTitle) {
+          visitedTitles.push(gameTitle.trim());
+        }
+      }
+    });
+
+    await test.step('Verify the recent-games breadcrumb keeps only the five newest visits', async () => {
+      const recentGamesList = page.getByTestId('recent-games-list');
+      const recentGameLinks = recentGamesList.locator('[data-testid^="recent-game-link-"]');
+
+      await expect(page.getByTestId('recent-games-breadcrumb')).toBeVisible();
+      await expect(page.getByTestId('recent-games-home-link')).toBeVisible();
+      await expect(recentGameLinks).toHaveCount(5);
+      await expect(page.getByTestId('recent-game-link-1')).toHaveCount(0);
+      await expect(recentGameLinks).toHaveText(visitedTitles.slice(-5).reverse());
+      await expect(page.getByTestId('recent-game-link-6')).toHaveAttribute('aria-current', 'page');
     });
   });
 

--- a/client/src/components/RecentGamesBreadcrumb.svelte
+++ b/client/src/components/RecentGamesBreadcrumb.svelte
@@ -1,33 +1,80 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import { getRecentPerusedGames, type RecentPerusedGame } from '../utils/recent-games';
+    import {
+        getRecentPerusedGames,
+        subscribeToRecentPerusedGames,
+        type RecentPerusedGame
+    } from '../utils/recent-games';
+
+    let {
+        currentGameId = undefined,
+        heading = 'Recently visited',
+        showCard = true,
+        showHomeLink = false
+    }: {
+        currentGameId?: number;
+        heading?: string;
+        showCard?: boolean;
+        showHomeLink?: boolean;
+    } = $props();
 
     let recentGames = $state<RecentPerusedGame[]>([]);
 
-    onMount(() => {
+    let containerClasses = $derived(
+        showCard
+            ? 'rounded-xl border border-slate-700 bg-slate-800/60 p-5 shadow-lg'
+            : 'rounded-xl border border-slate-700/80 bg-slate-900/70 p-4 shadow-md'
+    );
+
+    function loadRecentGames(): void {
         recentGames = getRecentPerusedGames();
+    }
+
+    onMount(() => {
+        loadRecentGames();
+        return subscribeToRecentPerusedGames((nextRecentGames) => {
+            recentGames = nextRecentGames;
+        });
     });
 </script>
 
-<div class="rounded-xl border border-slate-700 bg-slate-800/60 p-5 shadow-lg" data-testid="recent-games-breadcrumb">
-    <h2 class="text-lg font-semibold text-slate-100">Recently Perused</h2>
+<div class={containerClasses} data-testid="recent-games-breadcrumb">
+    <h2 class="text-lg font-semibold text-slate-100">{heading}</h2>
 
     {#if recentGames.length === 0}
         <p class="mt-3 text-sm text-slate-400" data-testid="recent-games-empty">
-            Peruse a few games and they&apos;ll show up here.
+            Visit a few games and they&apos;ll show up here.
         </p>
     {:else}
-        <nav class="mt-4" aria-label="Recently perused games breadcrumb">
-            <ol class="space-y-2" data-testid="recent-games-list">
+        <nav class="mt-4" aria-label={`${heading} breadcrumb`}>
+            <ol class="flex flex-wrap items-center gap-x-2 gap-y-3 text-sm text-slate-300" data-testid="recent-games-list">
+                {#if showHomeLink}
+                    <li class="flex items-center gap-2">
+                        <a
+                            href="/"
+                            class="font-semibold text-blue-200 transition-colors duration-200 hover:text-blue-100 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                            data-testid="recent-games-home-link"
+                        >
+                            Home
+                        </a>
+                        <span aria-hidden="true" class="text-slate-500">›</span>
+                    </li>
+                {/if}
+
                 {#each recentGames as recentGame, index (recentGame.id)}
-                    <li class="flex items-center gap-2 text-sm text-slate-300">
+                    <li class="flex items-center gap-2" data-testid={`recent-game-item-${recentGame.id}`}>
                         {#if index > 0}
                             <span aria-hidden="true" class="text-slate-500">›</span>
                         {/if}
                         <a
                             href={`/game/${recentGame.id}`}
-                            class="truncate font-semibold text-blue-300 transition-colors duration-200 hover:text-blue-200 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                            class={`truncate font-semibold transition-colors duration-200 focus:ring-2 focus:ring-blue-500 focus:outline-none ${
+                                currentGameId === recentGame.id
+                                    ? 'text-slate-100 underline decoration-blue-400 underline-offset-4'
+                                    : 'text-blue-200 hover:text-blue-100'
+                            }`}
                             data-testid={`recent-game-link-${recentGame.id}`}
+                            aria-current={currentGameId === recentGame.id ? 'page' : undefined}
                         >
                             {recentGame.title}
                         </a>

--- a/client/src/pages/game/[id].astro
+++ b/client/src/pages/game/[id].astro
@@ -2,6 +2,7 @@
 export const prerender = false;
 import Layout from '../../layouts/Layout.astro';
 import GameDetails from '../../components/GameDetails.svelte';
+import RecentGamesBreadcrumb from '../../components/RecentGamesBreadcrumb.svelte';
 
 const { id } = Astro.params;
 const gameId = parseInt(id || '0');
@@ -10,6 +11,16 @@ const gameId = parseInt(id || '0');
 
 <Layout title="Game Details - Tailspin Toys">
   <div class="py-8">
+    <div class="mb-6">
+      <RecentGamesBreadcrumb
+        client:load
+        currentGameId={gameId}
+        heading="Recent visits"
+        showCard={false}
+        showHomeLink={true}
+      />
+    </div>
+
     <GameDetails client:load gameId={gameId} />
     
     <div class="mt-8">

--- a/client/src/utils/recent-games.ts
+++ b/client/src/utils/recent-games.ts
@@ -7,6 +7,7 @@ export interface RecentPerusedGame {
 
 const RECENT_PERUSED_GAMES_STORAGE_KEY = 'tailspin-recent-perused-games';
 const RECENT_PERUSED_GAMES_LIMIT = 5;
+const RECENT_PERUSED_GAMES_UPDATED_EVENT = 'tailspin:recent-perused-games-updated';
 
 function isRecentPerusedGame(value: unknown): value is RecentPerusedGame {
     if (typeof value !== 'object' || value === null) {
@@ -50,4 +51,40 @@ export function addRecentPerusedGame(game: Pick<Game, 'id' | 'title'>): void {
         .slice(0, RECENT_PERUSED_GAMES_LIMIT);
 
     window.localStorage.setItem(RECENT_PERUSED_GAMES_STORAGE_KEY, JSON.stringify(nextRecentGames));
+    window.dispatchEvent(new CustomEvent<RecentPerusedGame[]>(RECENT_PERUSED_GAMES_UPDATED_EVENT, {
+        detail: nextRecentGames
+    }));
+}
+
+export function subscribeToRecentPerusedGames(
+    onRecentGamesChange: (recentGames: RecentPerusedGame[]) => void
+): () => void {
+    if (typeof window === 'undefined') {
+        return () => {};
+    }
+
+    const handleRecentGamesUpdate = (event: Event): void => {
+        if (event instanceof CustomEvent && Array.isArray(event.detail)) {
+            onRecentGamesChange(event.detail.filter(isRecentPerusedGame).slice(0, RECENT_PERUSED_GAMES_LIMIT));
+            return;
+        }
+
+        onRecentGamesChange(getRecentPerusedGames());
+    };
+
+    const handleStorageUpdate = (event: StorageEvent): void => {
+        if (event.key !== RECENT_PERUSED_GAMES_STORAGE_KEY) {
+            return;
+        }
+
+        onRecentGamesChange(getRecentPerusedGames());
+    };
+
+    window.addEventListener(RECENT_PERUSED_GAMES_UPDATED_EVENT, handleRecentGamesUpdate);
+    window.addEventListener('storage', handleStorageUpdate);
+
+    return () => {
+        window.removeEventListener(RECENT_PERUSED_GAMES_UPDATED_EVENT, handleRecentGamesUpdate);
+        window.removeEventListener('storage', handleStorageUpdate);
+    };
 }


### PR DESCRIPTION
## Description

This adds a recent-games breadcrumb trail so players can quickly jump between the titles they have viewed most recently. The goal is to make detail-page browsing feel more connected than the existing home-page-only recent history.

## Related Issue

Closes #87

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🧪 Test update
- [ ] 🔧 Refactor (no functional changes)

## Changes Made

- Reused the recent-games localStorage state as a shared source of truth and added a subscription helper so breadcrumb UIs update immediately after a visit.
- Extended the recent-games Svelte component so it can render both the existing card view and a breadcrumb-style trail with an optional Home link and current-page highlighting.
- Added the breadcrumb trail to game detail pages and capped the rendered history at the five most recent unique visits.
- Updated E2E coverage to verify the recent history appears, preserves order, and drops the oldest item once the limit is exceeded.
- Lightened the breadcrumb link color to improve readability in the dark theme.

## Testing

### Backend Changes

- [x] Ran `./scripts/run-server-tests.sh` - all tests pass
- [ ] Added/updated tests in `server/tests/` for API changes

### Frontend Changes

- [x] Ran `./scripts/run-e2e-tests.sh` - all tests pass
- [x] Added `data-testid` attributes to interactive elements
- [x] Verified build succeeds in `client/` directory

## Checklist

- [x] My code follows the project's coding standards
- [x] I have used type hints for Python functions (parameters and return values)
- [x] I have used Svelte 5 runes syntax (`$state`, `$props`, `$derived`) for components
- [x] I have followed the dark theme using Tailwind CSS utility classes
- [x] I have updated documentation (README, instruction files) if needed
- [x] My changes are focused on a single concern
- [x] I have written clear commit messages explaining what and why

## Additional Notes

This is a frontend-only change. I would appreciate an extra look at the breadcrumb wording and visual treatment on the game detail page.